### PR TITLE
feat: return number of new transparent addresses found during sweep

### DIFF
--- a/lib/pages/receive.dart
+++ b/lib/pages/receive.dart
@@ -116,7 +116,7 @@ class ReceivePageState extends State<ReceivePage> {
   void onSweep() async {
     showSnackbar("Starting sweep");
     final endHeight = await getCurrentHeight();
-    await transparentSweep(endHeight: endHeight, gapLimit: 40);
-    showSnackbar("Sweep complete");
+    final nAdded = await transparentSweep(endHeight: endHeight, gapLimit: 40);
+    showSnackbar("Sweep complete. $nAdded new addresses added");
   }
 }

--- a/lib/src/rust/api/account.dart
+++ b/lib/src/rust/api/account.dart
@@ -80,8 +80,7 @@ Future<List<TxNote>> listNotes() =>
 Future<void> lockNote({required int id, required bool locked}) =>
     RustLib.instance.api.crateApiAccountLockNote(id: id, locked: locked);
 
-Future<void> transparentSweep(
-        {required int endHeight, required int gapLimit}) =>
+Future<int> transparentSweep({required int endHeight, required int gapLimit}) =>
     RustLib.instance.api.crateApiAccountTransparentSweep(
         endHeight: endHeight, gapLimit: gapLimit);
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -203,7 +203,7 @@ abstract class RustLibApi extends BaseApi {
 
   TxPlan crateApiPayToPlan({required PcztPackage package});
 
-  Future<void> crateApiAccountTransparentSweep(
+  Future<int> crateApiAccountTransparentSweep(
       {required int endHeight, required int gapLimit});
 
   String crateApiAccountUaFromUfvk({required String ufvk, int? di});
@@ -1453,7 +1453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<void> crateApiAccountTransparentSweep(
+  Future<int> crateApiAccountTransparentSweep(
       {required int endHeight, required int gapLimit}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -1464,7 +1464,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             funcId: 51, port: port_);
       },
       codec: SseCodec(
-        decodeSuccessData: sse_decode_unit,
+        decodeSuccessData: sse_decode_u_32,
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiAccountTransparentSweepConstMeta,

--- a/rust/src/api/account.rs
+++ b/rust/src/api/account.rs
@@ -568,7 +568,7 @@ pub async fn lock_note(id: u32, locked: bool) -> Result<()> {
 }
 
 #[frb]
-pub async fn transparent_sweep(end_height: u32, gap_limit: u32) -> Result<()> {
+pub async fn transparent_sweep(end_height: u32, gap_limit: u32) -> Result<u32> {
     let c = get_coin!();
     crate::sync::transparent_sweep(
         &c.network,
@@ -578,8 +578,7 @@ pub async fn transparent_sweep(end_height: u32, gap_limit: u32) -> Result<()> {
         end_height,
         gap_limit,
     )
-    .await?;
-    Ok(())
+    .await
 }
 
 #[frb]

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -326,8 +326,8 @@ pub async fn store_account_transparent_addr(
     sk: Option<Vec<u8>>,
     pk: &[u8],
     address: &str,
-) -> Result<()> {
-    sqlx::query(
+) -> Result<bool> {
+    let r = sqlx::query(
         "INSERT INTO transparent_address_accounts(account, scope, dindex, sk, pk, address)
         VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING",
     )
@@ -340,7 +340,7 @@ pub async fn store_account_transparent_addr(
     .execute(connection)
     .await?;
 
-    Ok(())
+    Ok(r.rows_affected() > 0)
 }
 
 pub async fn init_account_sapling(connection: &SqlitePool, account: u32, birth: u32) -> Result<()> {


### PR DESCRIPTION
fix: reset_sync should not trim headers