### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/release-please.yml
     secrets: inherit
+    permissions:
+      contents: read
 
   build:
     if: "!contains(github.head_ref, 'release-please--')"


### PR DESCRIPTION
Potential fix for [https://github.com/hhanh00/zkool2/security/code-scanning/3](https://github.com/hhanh00/zkool2/security/code-scanning/3)

To fix this problem, you should add a `permissions` block either at the workflow root (if appropriate for all jobs), or specifically to the `release-please` job, since currently only the `build` job has one. Since best practice is to assign the least privilege required, start by granting read-only access to repository contents (`contents: read`). If the job needs to perform write operations, you can escalate only the necessary sub-types, such as `issues: write` or `pull-requests: write`. For a release automation job, the minimal recommended starting point is `contents: read`, and you can update as necessary if the job requires more permissions. You need to edit the relevant region of .github/workflows/ci.yml, specifically the `release-please` job block, to add the `permissions` key immediately before or after the `secrets: inherit` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
