### PR TITLE
Add case for Reverse 'txid' byte vector in db.rs

### DIFF
--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -1422,12 +1422,14 @@ fn get_sqlite_column_value(row: &SqliteRow, index: usize) -> Result<String> {
         v.to_string()
     } else if let Ok(v) = row.try_get::<String, _>(index) {
         v
-    } else if let Ok(v) = row.try_get::<Vec<u8>, _>(index) {
+    } else if let Ok(mut v) = row.try_get::<Vec<u8>, _>(index) {
+        if c.name() == "txid" {
+            v.reverse();
+        }
         hex::encode(&v)
     } else {
         unreachable!("{}", t.name())
     };
-
     Ok(v)
 }
 


### PR DESCRIPTION
Reverse the byte vector for 'txid' field before encoding.

This fixes a bug where the exported txid's are byte flipped the wrong way.