### PR TITLE
fix: exclude ZSA notes from ZEC value computations

### DIFF
--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -982,7 +982,7 @@ pub async fn list_accounts(connection: &mut SqliteConnection, coin: u8) -> Resul
         unspent AS (SELECT a.*
                 FROM notes a
                 LEFT JOIN spends b ON a.id_note = b.id_note
-                WHERE b.id_note IS NULL)
+                WHERE b.id_note IS NULL AND a.id_asset IS NULL)
         SELECT id_account, a.name, seed, passphrase, aindex, dindex,
         icon, birth, use_internal, a.position, hidden, saved, enabled, internal,
         sh.height, COALESCE(hdr.time, 0), COALESCE(SUM(unspent.value), 0) AS balance,

--- a/rust/src/memo.rs
+++ b/rust/src/memo.rs
@@ -53,7 +53,10 @@ pub async fn fetch_tx_details(
 
 async fn summarize_tx(connection: &mut SqliteConnection, tx: u32) -> Result<(u8, i64, Option<i32>, i64)> {
     let (value, fee) = sqlx::query(
-        "WITH n AS (SELECT value, tx FROM notes UNION ALL SELECT value, tx FROM spends)
+        "WITH n AS (SELECT value, tx FROM notes WHERE id_asset IS NULL
+                    UNION ALL
+                    SELECT s.value, s.tx FROM spends s
+                    JOIN notes n ON s.id_note = n.id_note WHERE n.id_asset IS NULL)
         SELECT SUM(n.value), t.fee FROM n JOIN transactions t ON t.id_tx = n.tx WHERE n.tx = ?",
     )
     .bind(tx)


### PR DESCRIPTION
Two places where ZSA (Zcash Shielded Asset) token values were leaking into ZEC totals:

1. **Transaction history net value** (`memo.rs`): The CTE in `summarize_tx` summing notes/spends had no `WHERE id_asset IS NULL` filter, causing ZSA amounts to inflate the net value shown per transaction.

2. **Account list balance** (`db.rs`): The `unspent` CTE in `list_accounts` had the same issue — ZSA values inflated the displayed account balance.

Both fixes add the missing `id_asset IS NULL` filter, matching the pattern already used correctly in `calculate_balance` and `max_spendable`.