### PR TITLE
fix: filter ZSA notes from ZEC value computations + issuance progress dialog

### DIFF
--- a/lib/pages/zsa.dart
+++ b/lib/pages/zsa.dart
@@ -1,3 +1,4 @@
+import 'package:awesome_dialog/awesome_dialog.dart';
 import 'package:convert/convert.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -190,7 +191,14 @@ class _IssueAssetPageState extends ConsumerState<IssueAssetPage> {
     );
     if (!confirmed) return;
 
+    AwesomeDialog? dialog;
     try {
+      dialog = await showMessage(
+        context,
+        "Building and broadcasting issuance transaction...",
+        dismissable: false,
+      );
+
       final txBytes = await issueAsset(
         assetName: assetName,
         amount: BigInt.parse(amount),
@@ -205,12 +213,17 @@ class _IssueAssetPageState extends ConsumerState<IssueAssetPage> {
         txBytes: txBytes,
         c: coinContext.coin,
       );
+
+      dialog.dismiss();
+      dialog = null;
+
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text("Transaction broadcast: $txid")),
       );
       GoRouter.of(context).pop();
     } on AnyhowException catch (e) {
+      dialog?.dismiss();
       if (mounted) await showException(context, e.message);
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -986,10 +986,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1446,26 +1446,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   toastification:
     dependency: "direct main"
     description:
@@ -1659,5 +1659,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/rust/src/api/issuance.rs
+++ b/rust/src/api/issuance.rs
@@ -127,13 +127,21 @@ pub async fn issue_asset(
 
     // Find an orchard note with sufficient value for fees.
     // Est. fee: 2 actions × 5k + 2 outputs × 5k ≈ 20k zats.
+    // We must select a ZEC note (asset_base == [0u8; 32]), not a ZSA note,
+    // because the fee and change output are in ZEC, not the ZSA asset.
     let est_fee: u64 = 10_000;
+    let zec_key = [0u8; 32];
     let orchard_note = unspent
         .iter()
-        .find(|n| n.pool == 2 && n.height <= height && n.amount >= est_fee)
+        .find(|n| {
+            n.pool == 2
+                && n.asset_base == zec_key
+                && n.height <= height
+                && n.amount >= est_fee
+        })
         .ok_or_else(|| {
             anyhow!(
-                "No unspent orchard note with ≥ {est_fee} zats available. \
+                "No unspent orchard ZEC note with ≥ {est_fee} zats available. \
                  An orchard note is required for issuance (provides the nullifier \
                  for rho derivation per ZIP-227). Shield some ZEC first."
             )

--- a/rust/src/pay/plan.rs
+++ b/rust/src/pay/plan.rs
@@ -284,11 +284,14 @@ pub async fn plan_transaction(
 
         }
 
-        // Replace inputs: keep non-orchard + ZEC orchard notes (ZSA notes already handled)
-        inputs = inputs.into_iter()
-            .filter(|n| !(n.pool == 2 && n.asset_base != zec_key))
-            .collect();
     }
+
+    // Filter ZSA orchard notes from inputs — they're handled above or are
+    // non-ZEC and shouldn't be selected for ZEC payments. This must run
+    // regardless of whether there were ZSA recipients.
+    inputs = inputs.into_iter()
+        .filter(|n| !(n.pool == 2 && n.asset_base != zec_key))
+        .collect();
 
     let recipient_states = zec_recipients;
 


### PR DESCRIPTION
## Changes

- **ZSA note filtering in issuance fees** (`rust/src/api/issuance.rs`): Add `asset_base == [0u8; 32]` check when selecting an Orchard note for fees, ensuring ZSA notes aren't mistakenly used (fees must be ZEC).
- **ZSA note filtering in payment planning** (`rust/src/pay/plan.rs`): Move the ZSA orchard note filter outside the `if zsa_recipients.is_some()` block so it always runs — preventing ZSA notes from being selected for ZEC payments even when there are no ZSA recipients.
- **Issuance progress dialog** (`lib/pages/zsa.dart`): Show a non-dismissible dialog while building and broadcasting issuance transactions, dismissed on success or error.
- **Dependency bumps** (`pubspec.lock`): Routine updates (meta, test packages).