### PR TITLE
feat: ZSA asset name display in transaction plan + holdings fixes

### DIFF
--- a/lib/pages/tx.dart
+++ b/lib/pages/tx.dart
@@ -241,19 +241,37 @@ SliverList showTxPlan(BuildContext context, TxPlan txPlan) {
     itemBuilder: (context, index) {
       if (index < txPlan.inputs.length) {
         final input = txPlan.inputs[index];
+        final isZsa = input.assetName != "ZEC";
         return ListTile(
           leading: Text("Input ${index + 1}"),
-          trailing: input.amount != null ? zatToText(input.amount!, selectable: true) : null,
-          subtitle: Text("Pool: ${poolToString(input.pool)}"),
+          trailing: input.amount != null
+              ? (isZsa
+                  ? Text(input.amount.toString(),
+                      style: TextStyle(
+                          color: Colors.purple, fontWeight: FontWeight.bold))
+                  : zatToText(input.amount!, selectable: true))
+              : null,
+          subtitle: Text([
+            "Pool: ${poolToString(input.pool)}",
+            if (isZsa) input.assetName,
+          ].join(" · ")),
         );
       } else {
         final index2 = index - txPlan.inputs.length;
         final output = txPlan.outputs[index2];
+        final isZsa = output.assetName != "ZEC";
         return ListTile(
           leading: Text("Output ${index2 + 1}"),
           title: Text("Address: ${output.address}"),
-          trailing: zatToText(output.amount, selectable: true),
-          subtitle: Text("Pool: ${poolToString(output.pool)}"),
+          trailing: isZsa
+              ? Text(output.amount.toString(),
+                  style: TextStyle(
+                      color: Colors.purple, fontWeight: FontWeight.bold))
+              : zatToText(output.amount, selectable: true),
+          subtitle: Text([
+            "Pool: ${poolToString(output.pool)}",
+            if (isZsa) output.assetName,
+          ].join(" · ")),
         );
       }
     },

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5520,11 +5520,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TxPlanIn dco_decode_tx_plan_in(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return TxPlanIn(
       pool: dco_decode_u_8(arr[0]),
       amount: dco_decode_opt_box_autoadd_u_64(arr[1]),
+      assetName: dco_decode_String(arr[2]),
     );
   }
 
@@ -5532,12 +5533,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TxPlanOut dco_decode_tx_plan_out(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TxPlanOut(
       pool: dco_decode_u_8(arr[0]),
       amount: dco_decode_u_64(arr[1]),
       address: dco_decode_String(arr[2]),
+      assetName: dco_decode_String(arr[3]),
     );
   }
 
@@ -6998,7 +7000,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_pool = sse_decode_u_8(deserializer);
     var var_amount = sse_decode_opt_box_autoadd_u_64(deserializer);
-    return TxPlanIn(pool: var_pool, amount: var_amount);
+    var var_assetName = sse_decode_String(deserializer);
+    return TxPlanIn(
+        pool: var_pool, amount: var_amount, assetName: var_assetName);
   }
 
   @protected
@@ -7007,7 +7011,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_pool = sse_decode_u_8(deserializer);
     var var_amount = sse_decode_u_64(deserializer);
     var var_address = sse_decode_String(deserializer);
-    return TxPlanOut(pool: var_pool, amount: var_amount, address: var_address);
+    var var_assetName = sse_decode_String(deserializer);
+    return TxPlanOut(
+        pool: var_pool,
+        amount: var_amount,
+        address: var_address,
+        assetName: var_assetName);
   }
 
   @protected
@@ -8295,6 +8304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_8(self.pool, serializer);
     sse_encode_opt_box_autoadd_u_64(self.amount, serializer);
+    sse_encode_String(self.assetName, serializer);
   }
 
   @protected
@@ -8303,6 +8313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_8(self.pool, serializer);
     sse_encode_u_64(self.amount, serializer);
     sse_encode_String(self.address, serializer);
+    sse_encode_String(self.assetName, serializer);
   }
 
   @protected

--- a/lib/src/rust/pay.dart
+++ b/lib/src/rust/pay.dart
@@ -95,14 +95,16 @@ class TxPlan {
 class TxPlanIn {
   final int pool;
   final BigInt? amount;
+  final String assetName;
 
   const TxPlanIn({
     required this.pool,
     this.amount,
+    required this.assetName,
   });
 
   @override
-  int get hashCode => pool.hashCode ^ amount.hashCode;
+  int get hashCode => pool.hashCode ^ amount.hashCode ^ assetName.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -110,22 +112,26 @@ class TxPlanIn {
       other is TxPlanIn &&
           runtimeType == other.runtimeType &&
           pool == other.pool &&
-          amount == other.amount;
+          amount == other.amount &&
+          assetName == other.assetName;
 }
 
 class TxPlanOut {
   final int pool;
   final BigInt amount;
   final String address;
+  final String assetName;
 
   const TxPlanOut({
     required this.pool,
     required this.amount,
     required this.address,
+    required this.assetName,
   });
 
   @override
-  int get hashCode => pool.hashCode ^ amount.hashCode ^ address.hashCode;
+  int get hashCode =>
+      pool.hashCode ^ amount.hashCode ^ address.hashCode ^ assetName.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -134,5 +140,6 @@ class TxPlanOut {
           runtimeType == other.runtimeType &&
           pool == other.pool &&
           amount == other.amount &&
-          address == other.address;
+          address == other.address &&
+          assetName == other.assetName;
 }

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		AD7091DF3C861A16BABB269A /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C390E2A7BC7D86E483C6C49 /* Pods_RunnerTests.framework */; };
 		F8111354221F250D85B46F52 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAD61125CDA26DFB88115AC7 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -82,6 +83,7 @@
 		5C390E2A7BC7D86E483C6C49 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		62C86B0E5BD2BCB359BA4ED0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		68D65DAB743FB7E9F419A7EB /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		9E50D911064C2C0433591705 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				F8111354221F250D85B46F52 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -164,6 +167,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -240,7 +244,6 @@
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				94E12D0493BB5923BD8B8CB6 /* [CP] Embed Pods Frameworks */,
-				431509C76F32BF1439CAA21F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -248,6 +251,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* zkool.app */;
 			productType = "com.apple.product-type.application";
@@ -270,7 +276,6 @@
 					33CC10EC2044A3C60003C045 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -292,6 +297,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -403,23 +411,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		431509C76F32BF1439CAA21F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		94E12D0493BB5923BD8B8CB6 /* [CP] Embed Pods Frameworks */ = {
@@ -589,8 +580,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8VSA3BX4D8;
 				ENABLE_APP_SANDBOX = YES;
@@ -613,7 +604,7 @@
 					"@executable_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = cc.methyl.zkool;
-				PROVISIONING_PROFILE_SPECIFIER = "zkool";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Profile;
@@ -738,8 +729,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8VSA3BX4D8;
 				ENABLE_APP_SANDBOX = YES;
@@ -762,7 +753,7 @@
 					"@executable_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = cc.methyl.zkool;
-				PROVISIONING_PROFILE_SPECIFIER = "zkool";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -775,8 +766,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8VSA3BX4D8;
 				ENABLE_APP_SANDBOX = NO;
@@ -796,7 +787,7 @@
 					"@executable_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = cc.methyl.zkool;
-				PROVISIONING_PROFILE_SPECIFIER = "zkool";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -861,6 +852,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,68 @@
+{
+  "pins" : [
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "65fb3f1aa6ffbfdc79c4e22178a55cd91561f5e9",
+        "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -1462,6 +1462,7 @@ pub async fn get_zsa_holdings(
            AND n.id_note NOT IN (SELECT id_note FROM spends)
            AND n.locked = 0
          GROUP BY a.id_asset
+         HAVING balance > 0
          ORDER BY a.asset_name, a.asset_desc_hash",
     )
     .bind(account)

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -6614,9 +6614,11 @@ impl SseDecode for crate::pay::TxPlanIn {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_pool = <u8>::sse_decode(deserializer);
         let mut var_amount = <Option<u64>>::sse_decode(deserializer);
+        let mut var_assetName = <String>::sse_decode(deserializer);
         return crate::pay::TxPlanIn {
             pool: var_pool,
             amount: var_amount,
+            asset_name: var_assetName,
         };
     }
 }
@@ -6627,10 +6629,12 @@ impl SseDecode for crate::pay::TxPlanOut {
         let mut var_pool = <u8>::sse_decode(deserializer);
         let mut var_amount = <u64>::sse_decode(deserializer);
         let mut var_address = <String>::sse_decode(deserializer);
+        let mut var_assetName = <String>::sse_decode(deserializer);
         return crate::pay::TxPlanOut {
             pool: var_pool,
             amount: var_amount,
             address: var_address,
+            asset_name: var_assetName,
         };
     }
 }
@@ -7863,6 +7867,7 @@ impl flutter_rust_bridge::IntoDart for crate::pay::TxPlanIn {
         [
             self.pool.into_into_dart().into_dart(),
             self.amount.into_into_dart().into_dart(),
+            self.asset_name.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -7880,6 +7885,7 @@ impl flutter_rust_bridge::IntoDart for crate::pay::TxPlanOut {
             self.pool.into_into_dart().into_dart(),
             self.amount.into_into_dart().into_dart(),
             self.address.into_into_dart().into_dart(),
+            self.asset_name.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8990,6 +8996,7 @@ impl SseEncode for crate::pay::TxPlanIn {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u8>::sse_encode(self.pool, serializer);
         <Option<u64>>::sse_encode(self.amount, serializer);
+        <String>::sse_encode(self.asset_name, serializer);
     }
 }
 
@@ -8999,6 +9006,7 @@ impl SseEncode for crate::pay::TxPlanOut {
         <u8>::sse_encode(self.pool, serializer);
         <u64>::sse_encode(self.amount, serializer);
         <String>::sse_encode(self.address, serializer);
+        <String>::sse_encode(self.asset_name, serializer);
     }
 }
 

--- a/rust/src/pay/mod.rs
+++ b/rust/src/pay/mod.rs
@@ -115,6 +115,7 @@ impl TxPlan {
                     inputs.push(TxPlanIn {
                         pool: 0,
                         amount: Some(value),
+                        asset_name: "ZEC".to_string(),
                     });
                     fee += value as i64;
                 }
@@ -125,6 +126,7 @@ impl TxPlan {
                         pool: 0,
                         amount: o.value().into_u64(),
                         address: address.encode(network),
+                        asset_name: "ZEC".to_string(),
                     });
                     fee -= o.value().into_u64() as i64;
                 }
@@ -138,6 +140,7 @@ impl TxPlan {
                     inputs.push(TxPlanIn {
                         pool: 1,
                         amount: None,
+                        asset_name: "ZEC".to_string(),
                     });
                 }
                 for o in bundle.outputs().iter() {
@@ -145,6 +148,7 @@ impl TxPlan {
                         pool: 1,
                         amount: o.value().unwrap().inner(),
                         address: o.user_address().as_ref().cloned().unwrap_or_default(),
+                        asset_name: "ZEC".to_string(),
                     });
                 }
                 fee += bundle.value_sum().to_raw() as i64;
@@ -155,9 +159,22 @@ impl TxPlan {
         let _verifier = verifier
             .with_orchard(|bundle| {
                 for a in bundle.actions().iter() {
+                    let input_asset_name = a
+                        .spend()
+                        .proprietary()
+                        .get("asset_name")
+                        .and_then(|v| String::from_utf8(v.clone()).ok())
+                        .unwrap_or_else(|| "ZEC".to_string());
+                    let output_asset_name = a
+                        .output()
+                        .proprietary()
+                        .get("asset_name")
+                        .and_then(|v| String::from_utf8(v.clone()).ok())
+                        .unwrap_or_else(|| "ZEC".to_string());
                     inputs.push(TxPlanIn {
                         pool: 2,
                         amount: None,
+                        asset_name: input_asset_name,
                     });
                     outputs.push(TxPlanOut {
                         pool: 2,
@@ -168,6 +185,7 @@ impl TxPlan {
                             .as_ref()
                             .cloned()
                             .unwrap_or_default(),
+                        asset_name: output_asset_name,
                     });
                 }
                 let f: i64 = (*bundle.value_sum()).try_into().unwrap();
@@ -191,6 +209,7 @@ impl TxPlan {
 pub struct TxPlanIn {
     pub pool: u8,
     pub amount: Option<u64>,
+    pub asset_name: String, // "ZEC" for ZEC, asset name for ZSA
 }
 
 #[derive(Serialize, Deserialize)]
@@ -198,6 +217,7 @@ pub struct TxPlanOut {
     pub pool: u8,
     pub amount: u64,
     pub address: String,
+    pub asset_name: String, // "ZEC" for ZEC, asset name for ZSA
 }
 
 pub async fn send(client: &mut Client, height: u32, data: &[u8]) -> Result<String> {

--- a/rust/src/pay/plan.rs
+++ b/rust/src/pay/plan.rs
@@ -565,6 +565,7 @@ pub async fn plan_transaction(
                 inputs.push(TxPlanIn {
                     amount: Some(*amount),
                     pool: *pool,
+                    asset_name: "ZEC".to_string(),
                 });
                 match pool {
                     0 => {
@@ -696,6 +697,10 @@ pub async fn plan_transaction(
             pool: pool_mask.to_best_pool().unwrap(),
             amount: recipient.amount,
             address: recipient.address.clone(),
+            asset_name: recipient
+                .asset_name
+                .clone()
+                .unwrap_or_else(|| "ZEC".to_string()),
         });
 
         let pool = pool_mask.to_best_pool().unwrap();
@@ -830,8 +835,71 @@ pub async fn plan_transaction(
         })
         .unwrap();
 
+    // Look up human-readable asset names from the assets table.
+    let asset_names: HashMap<Vec<u8>, String> = sqlx::query(
+        "SELECT asset_base, asset_name FROM assets WHERE asset_name IS NOT NULL AND asset_name != ''",
+    )
+    .map(|row: SqliteRow| {
+        let base: Vec<u8> = row.get(0);
+        let name: String = row.get(1);
+        (base, name)
+    })
+    .fetch_all(&mut *connection)
+    .await?
+    .into_iter()
+    .collect();
+
     let updater = updater
         .update_orchard_with(|mut u| {
+            // Collect asset info for ALL actions upfront (before any mutable
+            // access) so we can set proprietary on every action, including
+            // split spends, dummy outputs, and padding actions.
+            let action_count = u.bundle().actions().len();
+            let action_assets: Vec<(
+                Option<orchard::note::AssetBase>,
+                orchard::note::AssetBase,
+            )> = (0..action_count)
+                .map(|idx| {
+                    let a = &u.bundle().actions()[idx];
+                    (*a.spend().asset(), *a.output().asset())
+                })
+                .collect();
+
+            for action_idx in 0..action_count {
+                let (spend_asset_opt, output_asset) = &action_assets[action_idx];
+
+                let resolve = |a: &orchard::note::AssetBase| -> String {
+                    if bool::from(a.is_zatoshi()) {
+                        "ZEC".to_string()
+                    } else {
+                        let bytes = a.to_bytes().to_vec();
+                        asset_names
+                            .get(&bytes)
+                            .cloned()
+                            .unwrap_or_else(|| hex::encode(&bytes))
+                    }
+                };
+                let spend_name = match spend_asset_opt {
+                    Some(a) => resolve(a),
+                    None => "ZEC".to_string(),
+                };
+                let output_name = resolve(output_asset);
+
+                u.update_action_with(action_idx, |mut u| {
+                    u.set_spend_proprietary(
+                        "asset_name".to_string(),
+                        spend_name.as_bytes().to_vec(),
+                    );
+                    u.set_output_proprietary(
+                        "asset_name".to_string(),
+                        output_name.as_bytes().to_vec(),
+                    );
+                    Ok(())
+                })?;
+            }
+
+            // Set user_address on actions that have a real output (tracked
+            // by output_action_index).
             let mut i = 0;
             for o in outputs.iter() {
                 let pool = o.pool_mask.to_best_pool().unwrap();


### PR DESCRIPTION
## Changes

### ZSA asset names in transaction plan
- Store human-readable asset names as PCZT proprietary annotations on every orchard action (spend + output)
- Resolve names from the `assets` DB table, falling back to hex encoding
- Read back in `from_package` for the plan review screen
- Display ZSA outputs/inputs with purple text, raw amounts, and asset name

### ZSA holdings fixes
- Filter zero-balance ZSA holdings from the list (`HAVING balance > 0`)
- Filter ZSA notes from ZEC selection in issuance fee and payment planning

### Issuance UX
- Show progress dialog during issuance transaction building