### PR TITLE
fix: ZSA transaction type classification; hide payment URI for ZSA

### DIFF
--- a/lib/pages/send.dart
+++ b/lib/pages/send.dart
@@ -491,6 +491,7 @@ class Send2PageState extends ConsumerState<Send2Page> {
   late final c = coinContext.coin;
   String? txId;
   late final hasTex = widget.recipients.any((r) => isTexAddress(address: r.address, c: c));
+  late final hasZsa = widget.recipients.any((r) => !r.assetBase.every((b) => b == 0));
   var recipientPaysFee = false;
   int? category;
   var puri = "";
@@ -506,7 +507,8 @@ class Send2PageState extends ConsumerState<Send2Page> {
   void initState() {
     super.initState();
     Future(() async {
-      final uri = await buildPuri(recipients: widget.recipients);
+      // Payment URIs (ZIP-321) do not support ZSA assets.
+      final uri = hasZsa ? "" : await buildPuri(recipients: widget.recipients);
       final categoryList = await ref.read(getCategoriesProvider.future);
       final selectedAccount = ref.read(selectedAccountProvider).requireValue!;
       final data = (await ref.read(accountProvider(selectedAccount.id).future));
@@ -590,17 +592,18 @@ class Send2PageState extends ConsumerState<Send2Page> {
                 Gap(16),
                 Divider(),
                 Gap(8),
-                InputDecorator(
-                  decoration: InputDecoration(
-                    label: Text("Payment URI"),
-                    suffixIcon: IconButton(
-                      tooltip: "Show Payment URI",
-                      icon: Icon(Icons.qr_code),
-                      onPressed: onUriQr,
+                if (!hasZsa)
+                  InputDecorator(
+                    decoration: InputDecoration(
+                      label: Text("Payment URI"),
+                      suffixIcon: IconButton(
+                        tooltip: "Show Payment URI",
+                        icon: Icon(Icons.qr_code),
+                        onPressed: onUriQr,
+                      ),
                     ),
+                    child: CopyableText(puri),
                   ),
-                  child: CopyableText(puri),
-                ),
               ],
             ),
           ),

--- a/rust/src/memo.rs
+++ b/rust/src/memo.rs
@@ -88,10 +88,10 @@ async fn summarize_tx(connection: &mut SqliteConnection, tx: u32) -> Result<(u8,
     .await?
     .unwrap_or((None, 0));
 
-    if value > 0 {
+    if value > 0 || zsa_value > 0 {
         // receiving
         Ok((1, value, asset_id, zsa_value))
-    } else if value < -fee {
+    } else if value < -fee || zsa_value < 0 {
         // sending
         Ok((2, value, asset_id, zsa_value))
     } else {


### PR DESCRIPTION
## Changes

### Fix ZSA transaction type classification
In `rust/src/memo.rs:summarize_tx()`, the transaction type was determined solely by ZEC value. ZSA-only sends/receives (where ZEC value = 0) were incorrectly classified as "Self Transfer". Now `zsa_value` is included in the type check:
- `value > 0 || zsa_value > 0` → Receive
- `value < -fee || zsa_value < 0` → Send

### Hide payment URI for ZSA transactions
Payment URIs (ZIP-321) don't support ZSA assets, so the URI is now hidden on the "Extra Options" page when any recipient uses a non-ZEC asset.