### PR TITLE
feat: add SOCKS/HTTP proxy support with Arti Tor toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5820,6 +5820,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio 1.52.3",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -7223,6 +7224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio 1.52.3",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio 1.52.3",
 ]
 

--- a/assets/tor.svg
+++ b/assets/tor.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <!-- Tor onion mark: concentric onion rings with a vertical stem.
+       Drawn with currentColor so it inherits the IconButton foreground color. -->
+  <g fill="none" stroke="currentColor" stroke-width="1.6"
+     stroke-linecap="round" stroke-linejoin="round">
+    <!-- outer onion bulb -->
+    <path d="M12 21.2
+             C7.4 21.2 4.2 17.8 4.2 13.4
+             C4.2 8.4 8.0 4.2 12 2.8
+             C16.0 4.2 19.8 8.4 19.8 13.4
+             C19.8 17.8 16.6 21.2 12 21.2 Z"/>
+    <!-- middle ring -->
+    <path d="M12 18.6
+             C9.0 18.6 7.0 16.2 7.0 13.4
+             C7.0 10.2 9.3 7.2 12 6.0
+             C14.7 7.2 17.0 10.2 17.0 13.4
+             C17.0 16.2 15.0 18.6 12 18.6 Z"/>
+    <!-- inner ring -->
+    <path d="M12 16.0
+             C10.4 16.0 9.4 14.6 9.4 13.2
+             C9.4 11.4 10.6 9.8 12 9.0
+             C13.4 9.8 14.6 11.4 14.6 13.2
+             C14.6 14.6 13.6 16.0 12 16.0 Z"/>
+    <!-- vertical stem through the center -->
+    <line x1="12" y1="2.8" x2="12" y2="21.2"/>
+  </g>
+</svg>

--- a/lib/pages/splash.dart
+++ b/lib/pages/splash.dart
@@ -94,6 +94,7 @@ class SplashPageState extends ConsumerState<SplashPage> {
       url: settings.lwd,
     );
     c = await c.setUseTor(useTor: settings.useTor);
+    c = c.setProxy(proxy: settings.proxy);
     coinContext.set(coin: c);
     final synchronizer = ref.read(synchronizerProvider.notifier);
     synchronizer.autoSync();

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter_passkey_service/pigeons/messages.g.dart' show PasskeyExc
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:gap/gap.dart';
@@ -81,6 +82,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> with RouteAware {
         await prefs.setBool("pin_lock", settings.needPin);
         await prefs.setBool("offline", settings.offline);
         await prefs.setBool("use_tor", settings.useTor);
+        await putProp(key: "proxy", value: settings.proxy, c: c);
         await prefs.setBool("get_fx", settings.getFx);
         await prefs.setString("coingecko", settings.coingecko);
         await putProp(key: "qr_enabled", value: settings.qrSettings.enabled.toString(), c: c);
@@ -90,6 +92,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> with RouteAware {
         await putProp(key: "qr_repair", value: settings.qrSettings.repair.toString(), c: c);
         c = c.setLwd(url: settings.lwd, serverType: settings.isLightNode ? 0 : 1);
         c = await c.setUseTor(useTor: settings.useTor);
+        c = c.setProxy(proxy: settings.proxy);
         await prefs.setBool("vault", settings.vault);
         await prefs.setBool("expert_mode", settings.expertMode);
         await prefs.setString("palette_name", settings.paletteName);
@@ -198,17 +201,46 @@ class SettingsFormState extends ConsumerState<SettingsForm> {
                     ],
                   ),
                 ),
-                if (settings.isLightNode)
-                  Showcase(
-                    key: torID,
-                    description: "Use TOR to connect to lightwallet server. Need App Restart",
-                    child: FormBuilderSwitch(
-                      name: "tor",
-                      title: Text("Use TOR"),
-                      initialValue: settings.useTor,
-                      onChanged: onChangedUseTOR,
+                Row(
+                  children: [
+                    IconButton.outlined(
+                      tooltip: settings.useTor
+                          ? "Disable Arti Tor"
+                          : "Enable Arti Tor (embedded Tor client)",
+                      onPressed: onToggleTor,
+                      icon: SvgPicture.asset(
+                        "assets/tor.svg",
+                        width: 22,
+                        height: 22,
+                        colorFilter: ColorFilter.mode(
+                          settings.useTor ? Colors.green : Theme.of(context).colorScheme.primary,
+                          BlendMode.srcIn,
+                        ),
+                      ),
                     ),
-                  ),
+                    const Gap(4),
+                    Text(settings.useTor ? "Arti Tor enabled" : "Arti Tor disabled"),
+                    const Gap(24),
+                    Expanded(
+                      child: Showcase(
+                        key: torID,
+                        description: "Route connections through an external proxy. "
+                            "Supports socks5://, socks5h://, http:// and https://. "
+                            "Disabled when Arti Tor is enabled.",
+                        child: FormBuilderTextField(
+                          name: "proxy",
+                          decoration: const InputDecoration(
+                            labelText: "HTTP / SOCKS5 Proxy",
+                            hintText: "socks5h://127.0.0.1:9050",
+                          ),
+                          initialValue: settings.proxy,
+                          enabled: !settings.useTor,
+                          onChanged: onChangedProxy,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
                 Showcase(
                   key: actionsID,
                   description: "Number actions per synchronization chunk",
@@ -396,10 +428,17 @@ class SettingsFormState extends ConsumerState<SettingsForm> {
     });
   }
 
-  onChangedUseTOR(bool? value) async {
+  void onChangedProxy(String? value) async {
     if (value == null) return;
     setState(() {
-      settings = settings.copyWith(useTor: value);
+      settings = settings.copyWith(proxy: value);
+      widget.onChanged(settings);
+    });
+  }
+
+  void onToggleTor() async {
+    setState(() {
+      settings = settings.copyWith(useTor: !settings.useTor);
       widget.onChanged(settings);
     });
   }

--- a/lib/src/rust/api/coin.dart
+++ b/lib/src/rust/api/coin.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'coin.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `build_tor`, `client`, `connect_over_tor`, `get_connect_options`, `get_connection`, `get_pool`, `network`, `try_open`
+// These functions are ignored because they are not marked as `pub`: `build_tor`, `client`, `connect_over_proxy`, `connect_over_tor`, `get_connect_options`, `get_connection`, `get_pool`, `http_connect_tunnel`, `network`, `open_proxied_stream`, `try_open`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`
 
 Future<void> initDatadir({required String directory}) =>
@@ -26,6 +26,7 @@ sealed class Coin with _$Coin {
     required String url,
     required int serverType,
     required bool useTor,
+    required String proxy,
   }) = _Coin;
   Future<void> getName() => RustLib.instance.api.crateApiCoinCoinGetName(
         that: this,
@@ -43,6 +44,9 @@ sealed class Coin with _$Coin {
   Coin setLwd({required int serverType, required String url}) =>
       RustLib.instance.api
           .crateApiCoinCoinSetLwd(that: this, serverType: serverType, url: url);
+
+  Coin setProxy({required String proxy}) =>
+      RustLib.instance.api.crateApiCoinCoinSetProxy(that: this, proxy: proxy);
 
   Future<Coin> setUseTor({required bool useTor}) => RustLib.instance.api
       .crateApiCoinCoinSetUseTor(that: this, useTor: useTor);

--- a/lib/src/rust/api/coin.freezed.dart
+++ b/lib/src/rust/api/coin.freezed.dart
@@ -20,6 +20,7 @@ mixin _$Coin {
   String get url;
   int get serverType;
   bool get useTor;
+  String get proxy;
 
   /// Create a copy of Coin
   /// with the given fields replaced by the non-null parameter values.
@@ -40,16 +41,17 @@ mixin _$Coin {
             (identical(other.url, url) || other.url == url) &&
             (identical(other.serverType, serverType) ||
                 other.serverType == serverType) &&
-            (identical(other.useTor, useTor) || other.useTor == useTor));
+            (identical(other.useTor, useTor) || other.useTor == useTor) &&
+            (identical(other.proxy, proxy) || other.proxy == proxy));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, coin, account, dbFilepath, url, serverType, useTor);
+      runtimeType, coin, account, dbFilepath, url, serverType, useTor, proxy);
 
   @override
   String toString() {
-    return 'Coin(coin: $coin, account: $account, dbFilepath: $dbFilepath, url: $url, serverType: $serverType, useTor: $useTor)';
+    return 'Coin(coin: $coin, account: $account, dbFilepath: $dbFilepath, url: $url, serverType: $serverType, useTor: $useTor, proxy: $proxy)';
   }
 }
 
@@ -64,7 +66,8 @@ abstract mixin class $CoinCopyWith<$Res> {
       String dbFilepath,
       String url,
       int serverType,
-      bool useTor});
+      bool useTor,
+      String proxy});
 }
 
 /// @nodoc
@@ -85,6 +88,7 @@ class _$CoinCopyWithImpl<$Res> implements $CoinCopyWith<$Res> {
     Object? url = null,
     Object? serverType = null,
     Object? useTor = null,
+    Object? proxy = null,
   }) {
     return _then(_self.copyWith(
       coin: null == coin
@@ -111,6 +115,10 @@ class _$CoinCopyWithImpl<$Res> implements $CoinCopyWith<$Res> {
           ? _self.useTor
           : useTor // ignore: cast_nullable_to_non_nullable
               as bool,
+      proxy: null == proxy
+          ? _self.proxy
+          : proxy // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -207,7 +215,7 @@ extension CoinPatterns on Coin {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(int coin, int account, String dbFilepath, String url,
-            int serverType, bool useTor)?
+            int serverType, bool useTor, String proxy)?
         raw,
     required TResult orElse(),
   }) {
@@ -215,7 +223,7 @@ extension CoinPatterns on Coin {
     switch (_that) {
       case _Coin() when raw != null:
         return raw(_that.coin, _that.account, _that.dbFilepath, _that.url,
-            _that.serverType, _that.useTor);
+            _that.serverType, _that.useTor, _that.proxy);
       case _:
         return orElse();
     }
@@ -237,14 +245,14 @@ extension CoinPatterns on Coin {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(int coin, int account, String dbFilepath,
-            String url, int serverType, bool useTor)
+            String url, int serverType, bool useTor, String proxy)
         raw,
   }) {
     final _that = this;
     switch (_that) {
       case _Coin():
         return raw(_that.coin, _that.account, _that.dbFilepath, _that.url,
-            _that.serverType, _that.useTor);
+            _that.serverType, _that.useTor, _that.proxy);
     }
   }
 
@@ -263,14 +271,14 @@ extension CoinPatterns on Coin {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(int coin, int account, String dbFilepath, String url,
-            int serverType, bool useTor)?
+            int serverType, bool useTor, String proxy)?
         raw,
   }) {
     final _that = this;
     switch (_that) {
       case _Coin() when raw != null:
         return raw(_that.coin, _that.account, _that.dbFilepath, _that.url,
-            _that.serverType, _that.useTor);
+            _that.serverType, _that.useTor, _that.proxy);
       case _:
         return null;
     }
@@ -286,7 +294,8 @@ class _Coin extends Coin {
       required this.dbFilepath,
       required this.url,
       required this.serverType,
-      required this.useTor})
+      required this.useTor,
+      required this.proxy})
       : super._();
 
   @override
@@ -301,6 +310,8 @@ class _Coin extends Coin {
   final int serverType;
   @override
   final bool useTor;
+  @override
+  final String proxy;
 
   /// Create a copy of Coin
   /// with the given fields replaced by the non-null parameter values.
@@ -322,16 +333,17 @@ class _Coin extends Coin {
             (identical(other.url, url) || other.url == url) &&
             (identical(other.serverType, serverType) ||
                 other.serverType == serverType) &&
-            (identical(other.useTor, useTor) || other.useTor == useTor));
+            (identical(other.useTor, useTor) || other.useTor == useTor) &&
+            (identical(other.proxy, proxy) || other.proxy == proxy));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, coin, account, dbFilepath, url, serverType, useTor);
+      runtimeType, coin, account, dbFilepath, url, serverType, useTor, proxy);
 
   @override
   String toString() {
-    return 'Coin.raw(coin: $coin, account: $account, dbFilepath: $dbFilepath, url: $url, serverType: $serverType, useTor: $useTor)';
+    return 'Coin.raw(coin: $coin, account: $account, dbFilepath: $dbFilepath, url: $url, serverType: $serverType, useTor: $useTor, proxy: $proxy)';
   }
 }
 
@@ -347,7 +359,8 @@ abstract mixin class _$CoinCopyWith<$Res> implements $CoinCopyWith<$Res> {
       String dbFilepath,
       String url,
       int serverType,
-      bool useTor});
+      bool useTor,
+      String proxy});
 }
 
 /// @nodoc
@@ -368,6 +381,7 @@ class __$CoinCopyWithImpl<$Res> implements _$CoinCopyWith<$Res> {
     Object? url = null,
     Object? serverType = null,
     Object? useTor = null,
+    Object? proxy = null,
   }) {
     return _then(_Coin(
       coin: null == coin
@@ -394,6 +408,10 @@ class __$CoinCopyWithImpl<$Res> implements _$CoinCopyWith<$Res> {
           ? _self.useTor
           : useTor // ignore: cast_nullable_to_non_nullable
               as bool,
+      proxy: null == proxy
+          ? _self.proxy
+          : proxy // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -89,7 +89,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -58326072;
+  int get rustContentHash => -126677031;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -187,6 +187,8 @@ abstract class RustLibApi extends BaseApi {
 
   Coin crateApiCoinCoinSetLwd(
       {required Coin that, required int serverType, required String url});
+
+  Coin crateApiCoinCoinSetProxy({required Coin that, required String proxy});
 
   Future<Coin> crateApiCoinCoinSetUseTor(
       {required Coin that, required bool useTor});
@@ -1267,6 +1269,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Coin crateApiCoinCoinSetProxy({required Coin that, required String proxy}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_coin(that, serializer);
+          sse_encode_String(proxy, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_coin,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiCoinCoinSetProxyConstMeta,
+        argValues: [that, proxy],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiCoinCoinSetProxyConstMeta => const TaskConstMeta(
+        debugName: "coin_set_proxy",
+        argNames: ["that", "proxy"],
+      );
+
+  @override
   Future<Coin> crateApiCoinCoinSetUseTor(
       {required Coin that, required bool useTor}) {
     return handler.executeNormal(
@@ -1276,7 +1304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_coin(that, serializer);
           sse_encode_bool(useTor, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 25, port: port_);
+              funcId: 26, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_coin,
@@ -1304,7 +1332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_category(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 26, port: port_);
+              funcId: 27, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -1333,7 +1361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 27, port: port_);
+              funcId: 28, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_folder,
@@ -1360,7 +1388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(packet, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 28, port: port_);
+              funcId: 29, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_list_prim_u_8_strict,
@@ -1388,7 +1416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 29, port: port_);
+              funcId: 30, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1417,7 +1445,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_32_loose(ids, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 30, port: port_);
+              funcId: 31, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1446,7 +1474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_32_loose(ids, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 31, port: port_);
+              funcId: 32, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1476,7 +1504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_StreamSink_dkg_status_Sse(status, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 32, port: port_);
+                funcId: 33, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1507,7 +1535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_StreamSink_signing_status_Sse(status, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 33, port: port_);
+                funcId: 34, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1535,7 +1563,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_signing_event(a, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 34, port: port_);
+              funcId: 35, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1563,7 +1591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(path, serializer);
           sse_encode_box_autoadd_raptor_q_params(params, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 35, port: port_);
+              funcId: 36, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_list_prim_u_8_strict,
@@ -1588,7 +1616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 36, port: port_);
+              funcId: 37, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1617,7 +1645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(passphrase, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 37, port: port_);
+              funcId: 38, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1645,7 +1673,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_pczt_package(package, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 38, port: port_);
+              funcId: 39, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1676,7 +1704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 39, port: port_);
+              funcId: 40, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_record_u_32_f_64,
@@ -1706,7 +1734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(to, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 40, port: port_);
+              funcId: 41, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_record_string_f_64_bool,
@@ -1734,7 +1762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 41, port: port_);
+              funcId: 42, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_t_address_tx_count,
@@ -1763,7 +1791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 42, port: port_);
+              funcId: 43, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1791,7 +1819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(api, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 43, port: port_);
+              funcId: 44, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1817,7 +1845,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 44, port: port_);
+              funcId: 45, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_frost_sign_params,
@@ -1844,7 +1872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 45, port: port_);
+              funcId: 46, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1871,7 +1899,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 46, port: port_);
+              funcId: 47, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -1896,7 +1924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1925,7 +1953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_8(uaPools, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 48, port: port_);
+              funcId: 49, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_addresses,
@@ -1954,7 +1982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 49, port: port_);
+              funcId: 50, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1981,7 +2009,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 50, port: port_);
+              funcId: 51, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_frost_params,
@@ -2010,7 +2038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 51, port: port_);
+              funcId: 52, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -2039,7 +2067,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 52, port: port_);
+              funcId: 53, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_seed,
@@ -2069,7 +2097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_8(pools, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 53, port: port_);
+              funcId: 54, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2098,7 +2126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_8(uaPools, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 54, port: port_);
+              funcId: 55, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_addresses,
@@ -2125,7 +2153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(api, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 55, port: port_);
+              funcId: 56, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_64,
@@ -2152,7 +2180,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 56, port: port_);
+              funcId: 57, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -2179,7 +2207,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 57, port: port_);
+              funcId: 58, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_sync_height,
@@ -2205,7 +2233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 58, port: port_);
+              funcId: 59, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2234,7 +2262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_8(type, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 59, port: port_);
+              funcId: 60, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2261,7 +2289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -2289,7 +2317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(txId, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 61, port: port_);
+              funcId: 62, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2316,7 +2344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 62, port: port_);
+              funcId: 63, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2344,7 +2372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 63, port: port_);
+              funcId: 64, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -2369,7 +2397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2394,7 +2422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 65, port: port_);
+              funcId: 66, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2422,7 +2450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(idTx, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 66, port: port_);
+              funcId: 67, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_account,
@@ -2449,7 +2477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 67, port: port_);
+              funcId: 68, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2476,7 +2504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 68, port: port_);
+              funcId: 69, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2502,7 +2530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 69, port: port_);
+              funcId: 70, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2532,7 +2560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_8_loose(data, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 70, port: port_);
+              funcId: 71, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2558,7 +2586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 71, port: port_);
+              funcId: 72, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2583,7 +2611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 72, port: port_);
+              funcId: 73, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2609,7 +2637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(directory, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 73, port: port_);
+              funcId: 74, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2635,7 +2663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(directory, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 74, port: port_);
+              funcId: 75, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2661,7 +2689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 75, port: port_);
+              funcId: 76, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2694,7 +2722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 76, port: port_);
+              funcId: 77, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2722,7 +2750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_DartFn_Inputs_list_prim_u_8_strict_Output_unit_AnyhowException(
               append, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 77, port: port_);
+              funcId: 78, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2749,7 +2777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 78, port: port_);
+              funcId: 79, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2776,7 +2804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2801,7 +2829,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2827,7 +2855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(fvk, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2853,7 +2881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2878,7 +2906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(phrase, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2905,7 +2933,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2945,7 +2973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(idAccount, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 85, port: port_);
+              funcId: 86, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2987,7 +3015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 86, port: port_);
+              funcId: 87, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_account,
@@ -3014,7 +3042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 87, port: port_);
+              funcId: 88, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_category,
@@ -3041,7 +3069,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dir, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 88, port: port_);
+              funcId: 89, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3067,7 +3095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 89, port: port_);
+              funcId: 90, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_folder,
@@ -3093,7 +3121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 90, port: port_);
+              funcId: 91, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_memo,
@@ -3119,7 +3147,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 91, port: port_);
+              funcId: 92, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_tx_note,
@@ -3145,7 +3173,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 92, port: port_);
+              funcId: 93, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_tx,
@@ -3172,7 +3200,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 93, port: port_);
+              funcId: 94, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_zsa_holding,
@@ -3201,7 +3229,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(locked, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 94, port: port_);
+              funcId: 95, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3230,7 +3258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(threshold, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 95, port: port_);
+              funcId: 96, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3257,7 +3285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 96, port: port_);
+              funcId: 97, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -3286,7 +3314,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_new_account(na, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 97, port: port_);
+              funcId: 98, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -3312,7 +3340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 98, port: port_);
+              funcId: 99, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -3337,7 +3365,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(uri, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer,
+              funcId: 100)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_list_recipient,
@@ -3368,7 +3397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_payment_options(options, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 100, port: port_);
+              funcId: 101, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -3395,7 +3424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(id, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 101, port: port_);
+              funcId: 102, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3424,7 +3453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(value, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 102, port: port_);
+              funcId: 103, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3449,7 +3478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 103, port: port_);
+              funcId: 104, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_lwd_info,
@@ -3475,7 +3504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 104, port: port_);
+              funcId: 105, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_receivers,
@@ -3504,7 +3533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ua, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 105)!;
+              funcId: 106)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_receivers,
@@ -3533,7 +3562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(accountId, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 106, port: port_);
+              funcId: 107, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3562,7 +3591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_category(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 107, port: port_);
+              funcId: 108, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3592,7 +3621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 108, port: port_);
+              funcId: 109, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3622,7 +3651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(newPosition, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 109, port: port_);
+              funcId: 110, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3649,7 +3678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 110, port: port_);
+              funcId: 111, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3676,7 +3705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(id, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 111, port: port_);
+              funcId: 112, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3705,7 +3734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 112, port: port_);
+              funcId: 113, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3734,7 +3763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_8_loose(data, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 113, port: port_);
+              funcId: 114, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3763,7 +3792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 114, port: port_);
+              funcId: 115, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3792,7 +3821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 115, port: port_);
+              funcId: 116, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3829,7 +3858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(fundingAccount, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 116, port: port_);
+              funcId: 117, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3856,7 +3885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_StreamSink_log_message_Sse(s, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 117)!;
+              funcId: 118)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3886,7 +3915,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 118, port: port_);
+              funcId: 119, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3916,7 +3945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_f_64(price, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 119, port: port_);
+              funcId: 120, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3943,7 +3972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 120, port: port_);
+              funcId: 121, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3971,7 +4000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 121, port: port_);
+              funcId: 122, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4003,7 +4032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_box_autoadd_pczt_package(package, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 122, port: port_);
+                funcId: 123, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -4034,7 +4063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 123, port: port_);
+              funcId: 124, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -4069,7 +4098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 124, port: port_);
+              funcId: 125, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4111,7 +4140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_bool(fast, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 125, port: port_);
+                funcId: 126, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_u_32,
@@ -4158,7 +4187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(package, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 126)!;
+              funcId: 127)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_plan,
@@ -4183,7 +4212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 127, port: port_);
+              funcId: 128, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_account,
@@ -4209,7 +4238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 128, port: port_);
+              funcId: 129, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_memo,
@@ -4235,7 +4264,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 129, port: port_);
+              funcId: 130, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_note,
@@ -4261,7 +4290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 130, port: port_);
+              funcId: 131, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_output,
@@ -4287,7 +4316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 131, port: port_);
+              funcId: 132, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_spend,
@@ -4317,7 +4346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(di, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 132)!;
+              funcId: 133)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4343,7 +4372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 133, port: port_);
+              funcId: 134, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4370,7 +4399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(bytes, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 134, port: port_);
+              funcId: 135, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -4399,7 +4428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_account_update(update, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 135, port: port_);
+              funcId: 136, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4823,8 +4852,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Coin dco_decode_coin(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return Coin.raw(
       coin: dco_decode_u_8(arr[0]),
       account: dco_decode_u_32(arr[1]),
@@ -4832,6 +4861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       url: dco_decode_String(arr[3]),
       serverType: dco_decode_u_8(arr[4]),
       useTor: dco_decode_bool(arr[5]),
+      proxy: dco_decode_String(arr[6]),
     );
   }
 
@@ -6130,13 +6160,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_url = sse_decode_String(deserializer);
     var var_serverType = sse_decode_u_8(deserializer);
     var var_useTor = sse_decode_bool(deserializer);
+    var var_proxy = sse_decode_String(deserializer);
     return Coin.raw(
         coin: var_coin,
         account: var_account,
         dbFilepath: var_dbFilepath,
         url: var_url,
         serverType: var_serverType,
-        useTor: var_useTor);
+        useTor: var_useTor,
+        proxy: var_proxy);
   }
 
   @protected
@@ -7685,6 +7717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.url, serializer);
     sse_encode_u_8(self.serverType, serializer);
     sse_encode_bool(self.useTor, serializer);
+    sse_encode_String(self.proxy, serializer);
   }
 
   @protected

--- a/lib/store.dart
+++ b/lib/store.dart
@@ -327,6 +327,7 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
     final needPin = await prefs.getBool("pin_lock") ?? false;
     final offline = await prefs.getBool("offline") ?? false;
     final useTor = await prefs.getBool("use_tor") ?? false;
+    final proxy = (hasDb ? await getProp(key: "proxy", c: c) : null) ?? "";
     final getFx = await prefs.getBool("get_fx") ?? false;
     final coingecko = await prefs.getString("coingecko") ?? "";
     final recovery = await prefs.getBool("recovery") ?? false;
@@ -364,6 +365,7 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
       pinUnlockedAt: DateTime.now(),
       offline: offline,
       useTor: useTor,
+      proxy: proxy,
       getFx: getFx,
       coingecko: coingecko,
       recovery: recovery,
@@ -439,6 +441,7 @@ sealed class AppSettings with _$AppSettings {
     required String syncInterval, // in blocks
     required String actionsPerSync,
     required bool useTor,
+    required String proxy,
     required String coingecko,
     required bool recovery,
     required bool needPin,

--- a/lib/store.freezed.dart
+++ b/lib/store.freezed.dart
@@ -1333,6 +1333,7 @@ mixin _$AppSettings {
   String get syncInterval; // in blocks
   String get actionsPerSync;
   bool get useTor;
+  String get proxy;
   String get coingecko;
   bool get recovery;
   bool get needPin;
@@ -1369,6 +1370,7 @@ mixin _$AppSettings {
             (identical(other.actionsPerSync, actionsPerSync) ||
                 other.actionsPerSync == actionsPerSync) &&
             (identical(other.useTor, useTor) || other.useTor == useTor) &&
+            (identical(other.proxy, proxy) || other.proxy == proxy) &&
             (identical(other.coingecko, coingecko) ||
                 other.coingecko == coingecko) &&
             (identical(other.recovery, recovery) ||
@@ -1400,6 +1402,7 @@ mixin _$AppSettings {
         syncInterval,
         actionsPerSync,
         useTor,
+        proxy,
         coingecko,
         recovery,
         needPin,
@@ -1415,7 +1418,7 @@ mixin _$AppSettings {
 
   @override
   String toString() {
-    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
+    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
   }
 }
 
@@ -1434,6 +1437,7 @@ abstract mixin class $AppSettingsCopyWith<$Res> {
       String syncInterval,
       String actionsPerSync,
       bool useTor,
+      String proxy,
       String coingecko,
       bool recovery,
       bool needPin,
@@ -1469,6 +1473,7 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
     Object? syncInterval = null,
     Object? actionsPerSync = null,
     Object? useTor = null,
+    Object? proxy = null,
     Object? coingecko = null,
     Object? recovery = null,
     Object? needPin = null,
@@ -1514,6 +1519,10 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
           ? _self.useTor
           : useTor // ignore: cast_nullable_to_non_nullable
               as bool,
+      proxy: null == proxy
+          ? _self.proxy
+          : proxy // ignore: cast_nullable_to_non_nullable
+              as String,
       coingecko: null == coingecko
           ? _self.coingecko
           : coingecko // ignore: cast_nullable_to_non_nullable
@@ -1672,6 +1681,7 @@ extension AppSettingsPatterns on AppSettings {
             String syncInterval,
             String actionsPerSync,
             bool useTor,
+            String proxy,
             String coingecko,
             bool recovery,
             bool needPin,
@@ -1698,6 +1708,7 @@ extension AppSettingsPatterns on AppSettings {
             _that.syncInterval,
             _that.actionsPerSync,
             _that.useTor,
+            _that.proxy,
             _that.coingecko,
             _that.recovery,
             _that.needPin,
@@ -1738,6 +1749,7 @@ extension AppSettingsPatterns on AppSettings {
             String syncInterval,
             String actionsPerSync,
             bool useTor,
+            String proxy,
             String coingecko,
             bool recovery,
             bool needPin,
@@ -1763,6 +1775,7 @@ extension AppSettingsPatterns on AppSettings {
             _that.syncInterval,
             _that.actionsPerSync,
             _that.useTor,
+            _that.proxy,
             _that.coingecko,
             _that.recovery,
             _that.needPin,
@@ -1800,6 +1813,7 @@ extension AppSettingsPatterns on AppSettings {
             String syncInterval,
             String actionsPerSync,
             bool useTor,
+            String proxy,
             String coingecko,
             bool recovery,
             bool needPin,
@@ -1825,6 +1839,7 @@ extension AppSettingsPatterns on AppSettings {
             _that.syncInterval,
             _that.actionsPerSync,
             _that.useTor,
+            _that.proxy,
             _that.coingecko,
             _that.recovery,
             _that.needPin,
@@ -1854,6 +1869,7 @@ class _AppSettings implements AppSettings {
       required this.syncInterval,
       required this.actionsPerSync,
       required this.useTor,
+      required this.proxy,
       required this.coingecko,
       required this.recovery,
       required this.needPin,
@@ -1883,6 +1899,8 @@ class _AppSettings implements AppSettings {
   final String actionsPerSync;
   @override
   final bool useTor;
+  @override
+  final String proxy;
   @override
   final String coingecko;
   @override
@@ -1931,6 +1949,7 @@ class _AppSettings implements AppSettings {
             (identical(other.actionsPerSync, actionsPerSync) ||
                 other.actionsPerSync == actionsPerSync) &&
             (identical(other.useTor, useTor) || other.useTor == useTor) &&
+            (identical(other.proxy, proxy) || other.proxy == proxy) &&
             (identical(other.coingecko, coingecko) ||
                 other.coingecko == coingecko) &&
             (identical(other.recovery, recovery) ||
@@ -1962,6 +1981,7 @@ class _AppSettings implements AppSettings {
         syncInterval,
         actionsPerSync,
         useTor,
+        proxy,
         coingecko,
         recovery,
         needPin,
@@ -1977,7 +1997,7 @@ class _AppSettings implements AppSettings {
 
   @override
   String toString() {
-    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
+    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
   }
 }
 
@@ -1998,6 +2018,7 @@ abstract mixin class _$AppSettingsCopyWith<$Res>
       String syncInterval,
       String actionsPerSync,
       bool useTor,
+      String proxy,
       String coingecko,
       bool recovery,
       bool needPin,
@@ -2034,6 +2055,7 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
     Object? syncInterval = null,
     Object? actionsPerSync = null,
     Object? useTor = null,
+    Object? proxy = null,
     Object? coingecko = null,
     Object? recovery = null,
     Object? needPin = null,
@@ -2079,6 +2101,10 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
           ? _self.useTor
           : useTor // ignore: cast_nullable_to_non_nullable
               as bool,
+      proxy: null == proxy
+          ? _self.proxy
+          : proxy // ignore: cast_nullable_to_non_nullable
+              as String,
       coingecko: null == coingecko
           ? _self.coingecko
           : coingecko // ignore: cast_nullable_to_non_nullable

--- a/lib/store.g.dart
+++ b/lib/store.g.dart
@@ -505,7 +505,7 @@ final class AppSettingsNotifierProvider
 }
 
 String _$appSettingsNotifierHash() =>
-    r'cf43e2c9ac776d302b23a379c5c852dc1684d9ee';
+    r'a5f94ec12952b3d679b1208165f7d559434d037d';
 
 abstract class _$AppSettingsNotifier extends $AsyncNotifier<AppSettings> {
   FutureOr<AppSettings> build();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -604,6 +604,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1086,6 +1094,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -1586,6 +1602,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.5"
   vector_math:
     dependency: transitive
     description:
@@ -1683,5 +1723,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   toastification: ^3.0.2
 
   showcaseview: ^4.0.1
+  flutter_svg: ^2.0.10+1
 
   fixed: ^5.3.3
   decimal: ^3.2.1
@@ -97,3 +98,4 @@ flutter:
 
   assets:
     - misc/icon.png
+    - assets/tor.svg

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,7 +43,8 @@ arti-client = {version = "0.31", features = ["tokio", "native-tls", "onion-servi
 httparse = "1.10.1"
 hyper-util = {version = "0.1", features = ["tokio"]}
 rayon = "1.10"
-reqwest = {version = "0.12", features = ["json", "rustls-tls"]}
+reqwest = {version = "0.12", features = ["json", "rustls-tls", "socks"]}
+tokio-socks = "0.5.2"
 tor-rtcompat = {version = "0.31", features = ["tokio", "native-tls"]}
 tower = "0.5"
 

--- a/rust/src/api/coin.rs
+++ b/rust/src/api/coin.rs
@@ -32,6 +32,9 @@ pub struct Coin {
     pub url: String,
     pub server_type: u8,
     pub use_tor: bool,
+    /// Optional external proxy URL: socks5://, socks5h://, http://, https://.
+    /// Empty string means a direct connection.
+    pub proxy: String,
 }
 
 impl Coin {
@@ -145,16 +148,27 @@ impl Coin {
         })
     }
 
+    #[cfg_attr(feature = "flutter", frb(sync))]
+    pub fn set_proxy(self, proxy: String) -> Result<Self> {
+        Ok(Coin { proxy, ..self })
+    }
+
     pub(crate) async fn client(&self) -> Result<Client> {
         match self.server_type {
+            // lightwalletd (gRPC). Precedence: Tor (arti) > external proxy > direct.
             0 if self.use_tor => {
                 let channel = connect_over_tor(&self.url).await?;
-
                 let client = CompactTxStreamerClient::new(channel);
                 Ok(Box::new(client) as Client)
             }
 
-            0 if !self.use_tor => {
+            0 if !self.proxy.is_empty() => {
+                let channel = connect_over_proxy(&self.url, &self.proxy).await?;
+                let client = CompactTxStreamerClient::new(channel);
+                Ok(Box::new(client) as Client)
+            }
+
+            0 => {
                 let mut channel = tonic::transport::Channel::from_shared(self.url.clone())?;
                 if self.url.starts_with("https") {
                     let tls = ClientTlsConfig::new().with_enabled_roots();
@@ -165,7 +179,7 @@ impl Coin {
             }
 
             1 => {
-                let client = ZebraClient::new(&self.network(), &self.url)?;
+                let client = ZebraClient::new(&self.network(), &self.url, &self.proxy)?;
                 Ok(Box::new(client) as Client)
             }
 
@@ -251,6 +265,146 @@ async fn connect_over_tor(url: &str) -> anyhow::Result<Channel> {
     Ok(endpoint.connect_with_connector(connector).await?)
 }
 
+/// Build a tonic Channel to `url` whose TCP connection is established through an
+/// external proxy. Supports socks5://, socks5h://, http:// and https:// proxies.
+async fn connect_over_proxy(url: &str, proxy: &str) -> anyhow::Result<Channel> {
+    let uri = url.parse::<Uri>()?;
+    let host = uri
+        .host()
+        .ok_or_else(|| anyhow::anyhow!("no host"))?
+        .to_string();
+    let port = uri.port_u16().unwrap_or_else(|| {
+        if uri.scheme_str() == Some("https") {
+            443
+        } else {
+            80
+        }
+    });
+
+    let proxy = proxy.to_string();
+    let connector = service_fn(move |_dst| {
+        let host = host.clone();
+        let proxy = proxy.clone();
+        async move {
+            let stream = open_proxied_stream(&proxy, &host, port).await?;
+            let compat_stream = TokioIo::new(stream);
+            Ok::<_, anyhow::Error>(compat_stream)
+        }
+    });
+
+    let mut endpoint = Endpoint::from_shared(url.to_string())?;
+    if url.starts_with("https") {
+        let tls = ClientTlsConfig::new().with_enabled_roots();
+        endpoint = endpoint.tls_config(tls)?;
+    }
+
+    Ok(endpoint.connect_with_connector(connector).await?)
+}
+
+/// Open a TCP stream to (`target_host`, `target_port`) through `proxy`.
+/// Returns a tokio stream usable as the transport for a single connection.
+pub(crate) async fn open_proxied_stream(
+    proxy: &str,
+    target_host: &str,
+    target_port: u16,
+) -> anyhow::Result<tokio::net::TcpStream> {
+    let puri = proxy.parse::<Uri>()?;
+    let scheme = puri.scheme_str().unwrap_or("").to_lowercase();
+    let phost = puri
+        .host()
+        .ok_or_else(|| anyhow::anyhow!("proxy has no host"))?;
+    let pport = puri.port_u16().unwrap_or(match scheme.as_str() {
+        "socks5" | "socks5h" => 1080,
+        "https" => 443,
+        _ => 8080,
+    });
+
+    match scheme.as_str() {
+        // socks5h => resolve the target hostname *at the proxy* (remote DNS).
+        // This is what allows .onion addresses to work and prevents DNS leaks,
+        // so it is the recommended scheme for Tor.
+        "socks5h" => {
+            let stream = tokio_socks::tcp::Socks5Stream::connect(
+                (phost, pport),
+                // Passing a &str target makes tokio-socks send the hostname to
+                // the proxy as a SOCKS5 DOMAINNAME request (proxy-side DNS).
+                (target_host, target_port),
+            )
+            .await?;
+            Ok(stream.into_inner())
+        }
+        // socks5 => resolve the target hostname locally and send the IP to the
+        // proxy. We resolve here explicitly so the distinction from socks5h is
+        // honoured even though tokio-socks would otherwise defer to the proxy.
+        "socks5" => {
+            let mut addrs =
+                tokio::net::lookup_host((target_host, target_port)).await?;
+            let target_addr = addrs
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("could not resolve {target_host}"))?;
+            let stream = tokio_socks::tcp::Socks5Stream::connect(
+                (phost, pport),
+                target_addr,
+            )
+            .await?;
+            Ok(stream.into_inner())
+        }
+        "http" | "https" => http_connect_tunnel(phost, pport, target_host, target_port).await,
+        other => anyhow::bail!("unsupported proxy scheme: {other}"),
+    }
+}
+
+/// Establish an HTTP CONNECT tunnel through an http(s) proxy and return the
+/// raw TCP stream (post-handshake) ready for TLS/HTTP2 to run over.
+async fn http_connect_tunnel(
+    proxy_host: &str,
+    proxy_port: u16,
+    target_host: &str,
+    target_port: u16,
+) -> anyhow::Result<tokio::net::TcpStream> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = tokio::net::TcpStream::connect((proxy_host, proxy_port)).await?;
+    let req = format!(
+        "CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n",
+        host = target_host,
+        port = target_port
+    );
+    stream.write_all(req.as_bytes()).await?;
+    stream.flush().await?;
+
+    // Read until we have the full status line + headers (terminated by \r\n\r\n).
+    let mut buf = Vec::with_capacity(256);
+    let mut tmp = [0u8; 256];
+    loop {
+        let n = stream.read(&mut tmp).await?;
+        if n == 0 {
+            anyhow::bail!("proxy closed connection during CONNECT");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if buf.len() > 8192 {
+            anyhow::bail!("CONNECT response headers too large");
+        }
+    }
+
+    let head = String::from_utf8_lossy(&buf);
+    let status_line = head.lines().next().unwrap_or("");
+    // Expect "HTTP/1.1 200 ..." (any 2xx is acceptable).
+    let ok = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|c| c.parse::<u16>().ok())
+        .map(|c| (200..300).contains(&c))
+        .unwrap_or(false);
+    if !ok {
+        anyhow::bail!("proxy CONNECT failed: {status_line}");
+    }
+    Ok(stream)
+}
+
 impl Coin {
     #[cfg_attr(feature = "flutter", frb(sync))]
     pub fn new() -> Self {
@@ -261,6 +415,7 @@ impl Coin {
             server_type: 0,
             url: String::new(),
             use_tor: false,
+            proxy: String::new(),
         }
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -58326072;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -126677031;
 
 // Section: executor
 
@@ -1162,6 +1162,39 @@ fn wire__crate__api__coin__coin_set_lwd_impl(
                 (move || {
                     let output_ok =
                         crate::api::coin::Coin::set_lwd(api_that, api_server_type, api_url)?;
+                    Ok(output_ok)
+                })(),
+            )
+        },
+    )
+}
+fn wire__crate__api__coin__coin_set_proxy_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "coin_set_proxy",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::coin::Coin>::sse_decode(&mut deserializer);
+            let api_proxy = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                (move || {
+                    let output_ok = crate::api::coin::Coin::set_proxy(api_that, api_proxy)?;
                     Ok(output_ok)
                 })(),
             )
@@ -5617,6 +5650,7 @@ impl SseDecode for crate::api::coin::Coin {
         let mut var_url = <String>::sse_decode(deserializer);
         let mut var_serverType = <u8>::sse_decode(deserializer);
         let mut var_useTor = <bool>::sse_decode(deserializer);
+        let mut var_proxy = <String>::sse_decode(deserializer);
         return crate::api::coin::Coin {
             coin: var_coin,
             account: var_account,
@@ -5624,6 +5658,7 @@ impl SseDecode for crate::api::coin::Coin {
             url: var_url,
             server_type: var_serverType,
             use_tor: var_useTor,
+            proxy: var_proxy,
         };
     }
 }
@@ -6942,172 +6977,172 @@ fn pde_ffi_dispatcher_primary_impl(
         20 => wire__crate__api__coin__coin_get_name_impl(port, ptr, rust_vec_len, data_len),
         22 => wire__crate__api__coin__coin_open_database_impl(port, ptr, rust_vec_len, data_len),
         23 => wire__crate__api__coin__coin_set_account_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__coin__coin_set_use_tor_impl(port, ptr, rust_vec_len, data_len),
-        26 => {
+        26 => wire__crate__api__coin__coin_set_use_tor_impl(port, ptr, rust_vec_len, data_len),
+        27 => {
             wire__crate__api__account__create_new_category_impl(port, ptr, rust_vec_len, data_len)
         }
-        27 => wire__crate__api__account__create_new_folder_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__raptor__decode_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__account__delete_account_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__account__delete_categories_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__account__delete_folders_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__frost__do_dkg_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__frost__do_sign_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__account__dummy_export_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__raptor__encode_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__raptor__end_decode_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__account__export_account_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__pay__extract_transaction_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__transaction__fetch_amounts_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__transaction__fetch_category_amounts_impl(
+        28 => wire__crate__api__account__create_new_folder_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__raptor__decode_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__account__delete_account_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__account__delete_categories_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__account__delete_folders_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__frost__do_dkg_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__frost__do_sign_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__account__dummy_export_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__raptor__encode_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__raptor__end_decode_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__account__export_account_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__pay__extract_transaction_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__transaction__fetch_amounts_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__transaction__fetch_category_amounts_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__account__fetch_transparent_address_tx_count_impl(
+        42 => wire__crate__api__account__fetch_transparent_address_tx_count_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__sync__fetch_tx_details_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__transaction__fill_missing_tx_prices_impl(
+        43 => wire__crate__api__sync__fetch_tx_details_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__transaction__fill_missing_tx_prices_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__frost__frost_sign_params_default_impl(
+        45 => wire__crate__api__frost__frost_sign_params_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__account__generate_next_change_address_impl(
+        46 => wire__crate__api__account__generate_next_change_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => {
+        47 => {
             wire__crate__api__account__generate_next_dindex_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => {
+        49 => {
             wire__crate__api__account__get_account_addresses_impl(port, ptr, rust_vec_len, data_len)
         }
-        49 => wire__crate__api__account__get_account_fingerprint_impl(
+        50 => wire__crate__api__account__get_account_fingerprint_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__api__account__get_account_frost_params_impl(
+        51 => wire__crate__api__account__get_account_frost_params_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__account__get_account_pools_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__account__get_account_seed_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__account__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__account__get_addresses_impl(port, ptr, rust_vec_len, data_len),
-        55 => {
+        52 => wire__crate__api__account__get_account_pools_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__account__get_account_seed_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__account__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__account__get_addresses_impl(port, ptr, rust_vec_len, data_len),
+        56 => {
             wire__crate__api__network__get_coingecko_price_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__network__get_current_height_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__sync__get_db_height_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__frost__get_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__account__get_exported_data_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__mempool__get_mempool_tx_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__network__get_network_name_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__db__get_prop_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__coin__get_tor_client_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__account__get_tx_details_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__frost__has_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__frost__has_dkg_params_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__account__has_transparent_pub_key_impl(
+        57 => wire__crate__api__network__get_current_height_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__sync__get_db_height_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__frost__get_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__account__get_exported_data_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__mempool__get_mempool_tx_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__network__get_network_name_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__db__get_prop_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__coin__get_tor_client_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__account__get_tx_details_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__frost__has_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__frost__has_dkg_params_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__account__has_transparent_pub_key_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__account__import_account_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__init__init_app_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__raptor__init_app_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__crate__api__coin__init_datadir_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__network__init_datadir_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__frost__init_dkg_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__frost__init_sign_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__vault__init_vault_impl(port, ptr, rust_vec_len, data_len),
-        78 => {
+        71 => wire__crate__api__account__import_account_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__init__init_app_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__raptor__init_app_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__coin__init_datadir_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__network__init_datadir_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__api__frost__init_dkg_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__frost__init_sign_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__vault__init_vault_impl(port, ptr, rust_vec_len, data_len),
+        79 => {
             wire__crate__api__frost__is_signing_in_progress_impl(port, ptr, rust_vec_len, data_len)
         }
-        85 => wire__crate__api__issuance__issue_asset_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__account__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__account__list_categories_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__db__list_db_names_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__account__list_folders_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__account__list_memos_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__account__list_notes_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__account__list_tx_history_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__zsa__list_zsa_holdings_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__account__lock_note_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__account__lock_recent_notes_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__account__max_spendable_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__account__new_account_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__pay__pack_transaction_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__pay__prepare_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__account__print_keys_impl(port, ptr, rust_vec_len, data_len),
-        102 => wire__crate__api__db__put_prop_impl(port, ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__network__query_lwd_list_impl(port, ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__account__receivers_default_impl(port, ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__account__remove_account_impl(port, ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__account__rename_category_impl(port, ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__account__rename_folder_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__account__reorder_account_impl(port, ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__frost__reset_sign_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__account__reset_sync_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__sync__rewind_sync_impl(port, ptr, rust_vec_len, data_len),
-        113 => wire__crate__api__pay__send_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__zsa__set_asset_name_impl(port, ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__frost__set_dkg_address_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__frost__set_dkg_params_impl(port, ptr, rust_vec_len, data_len),
-        118 => {
+        86 => wire__crate__api__issuance__issue_asset_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__account__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__account__list_categories_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__db__list_db_names_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__account__list_folders_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__account__list_memos_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__account__list_notes_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__account__list_tx_history_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__zsa__list_zsa_holdings_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__account__lock_note_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__account__lock_recent_notes_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__account__max_spendable_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__account__new_account_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__pay__pack_transaction_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__pay__prepare_impl(port, ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__account__print_keys_impl(port, ptr, rust_vec_len, data_len),
+        103 => wire__crate__api__db__put_prop_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__network__query_lwd_list_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__account__receivers_default_impl(port, ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__account__remove_account_impl(port, ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__account__rename_category_impl(port, ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__account__rename_folder_impl(port, ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__account__reorder_account_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__frost__reset_sign_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__account__reset_sync_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__sync__rewind_sync_impl(port, ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__pay__send_impl(port, ptr, rust_vec_len, data_len),
+        115 => wire__crate__api__zsa__set_asset_name_impl(port, ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__frost__set_dkg_address_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__frost__set_dkg_params_impl(port, ptr, rust_vec_len, data_len),
+        119 => {
             wire__crate__api__transaction__set_tx_category_impl(port, ptr, rust_vec_len, data_len)
         }
-        119 => wire__crate__api__transaction__set_tx_price_impl(port, ptr, rust_vec_len, data_len),
-        120 => wire__crate__api__account__show_ledger_sapling_address_impl(
+        120 => wire__crate__api__transaction__set_tx_price_impl(port, ptr, rust_vec_len, data_len),
+        121 => wire__crate__api__account__show_ledger_sapling_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        121 => wire__crate__api__account__show_ledger_transparent_address_impl(
+        122 => wire__crate__api__account__show_ledger_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        122 => wire__crate__api__account__sign_ledger_transaction_impl(
+        123 => wire__crate__api__account__sign_ledger_transaction_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        123 => wire__crate__api__pay__sign_transaction_impl(port, ptr, rust_vec_len, data_len),
-        124 => wire__crate__api__pay__store_pending_tx_impl(port, ptr, rust_vec_len, data_len),
-        125 => wire__crate__api__sync__synchronize_impl(port, ptr, rust_vec_len, data_len),
-        127 => {
+        124 => wire__crate__api__pay__sign_transaction_impl(port, ptr, rust_vec_len, data_len),
+        125 => wire__crate__api__pay__store_pending_tx_impl(port, ptr, rust_vec_len, data_len),
+        126 => wire__crate__api__sync__synchronize_impl(port, ptr, rust_vec_len, data_len),
+        128 => {
             wire__crate__api__account__tx_account_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        128 => wire__crate__api__account__tx_memo_default_impl(port, ptr, rust_vec_len, data_len),
-        129 => wire__crate__api__account__tx_note_default_impl(port, ptr, rust_vec_len, data_len),
-        130 => wire__crate__api__account__tx_output_default_impl(port, ptr, rust_vec_len, data_len),
-        131 => wire__crate__api__account__tx_spend_default_impl(port, ptr, rust_vec_len, data_len),
-        133 => wire__crate__api__account__unlock_all_notes_impl(port, ptr, rust_vec_len, data_len),
-        134 => wire__crate__api__pay__unpack_transaction_impl(port, ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__account__update_account_impl(port, ptr, rust_vec_len, data_len),
+        129 => wire__crate__api__account__tx_memo_default_impl(port, ptr, rust_vec_len, data_len),
+        130 => wire__crate__api__account__tx_note_default_impl(port, ptr, rust_vec_len, data_len),
+        131 => wire__crate__api__account__tx_output_default_impl(port, ptr, rust_vec_len, data_len),
+        132 => wire__crate__api__account__tx_spend_default_impl(port, ptr, rust_vec_len, data_len),
+        134 => wire__crate__api__account__unlock_all_notes_impl(port, ptr, rust_vec_len, data_len),
+        135 => wire__crate__api__pay__unpack_transaction_impl(port, ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__account__update_account_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -7123,20 +7158,21 @@ fn pde_ffi_dispatcher_sync_impl(
         8 => wire__crate__api__mempool__Mempool_new_impl(ptr, rust_vec_len, data_len),
         21 => wire__crate__api__coin__coin_new_impl(ptr, rust_vec_len, data_len),
         24 => wire__crate__api__coin__coin_set_lwd_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__key__generate_seed_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__key__get_key_pools_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__raptor__get_qr_bytes_impl(ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__key__is_tex_address_impl(ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__key__is_valid_address_impl(ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__key__is_valid_fvk_impl(ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__key__is_valid_key_impl(ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__key__is_valid_phrase_impl(ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__key__is_valid_transparent_address_impl(ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__pay__parse_payment_uri_impl(ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__account__receivers_from_ua_impl(ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__init__set_log_stream_impl(ptr, rust_vec_len, data_len),
-        126 => wire__crate__api__pay__to_plan_impl(ptr, rust_vec_len, data_len),
-        132 => wire__crate__api__account__ua_from_ufvk_impl(ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__coin__coin_set_proxy_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__key__generate_seed_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__key__get_key_pools_impl(ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__raptor__get_qr_bytes_impl(ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__key__is_tex_address_impl(ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__key__is_valid_address_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__key__is_valid_fvk_impl(ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__key__is_valid_key_impl(ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__key__is_valid_phrase_impl(ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__key__is_valid_transparent_address_impl(ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__pay__parse_payment_uri_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__account__receivers_from_ua_impl(ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__init__set_log_stream_impl(ptr, rust_vec_len, data_len),
+        127 => wire__crate__api__pay__to_plan_impl(ptr, rust_vec_len, data_len),
+        133 => wire__crate__api__account__ua_from_ufvk_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -7307,6 +7343,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::coin::Coin {
             self.url.into_into_dart().into_dart(),
             self.server_type.into_into_dart().into_dart(),
             self.use_tor.into_into_dart().into_dart(),
+            self.proxy.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8337,6 +8374,7 @@ impl SseEncode for crate::api::coin::Coin {
         <String>::sse_encode(self.url, serializer);
         <u8>::sse_encode(self.server_type, serializer);
         <bool>::sse_encode(self.use_tor, serializer);
+        <String>::sse_encode(self.proxy, serializer);
     }
 }
 

--- a/rust/src/net/zebra.rs
+++ b/rust/src/net/zebra.rs
@@ -44,8 +44,17 @@ pub struct ZebraClient {
 }
 
 impl ZebraClient {
-    pub fn new(network: &Network, url: &str) -> Result<Self> {
-        let client = reqwest::Client::new();
+    pub fn new(network: &Network, url: &str, proxy: &str) -> Result<Self> {
+        // Route Zebra (full node) JSON-RPC through the configured proxy when set.
+        // reqwest natively supports socks5/socks5h/http/https proxy URLs.
+        let client = if proxy.is_empty() {
+            reqwest::Client::new()
+        } else {
+            reqwest::Client::builder()
+                .proxy(reqwest::Proxy::all(proxy).anyhow()?)
+                .build()
+                .anyhow()?
+        };
 
         let url = Url::parse(url).anyhow()?;
         let host = url.domain().ok_or(anyhow::anyhow!("Not domain"))?;


### PR DESCRIPTION
## Summary
Adds proxy support for routing wallet connections through an external proxy or the embedded Arti Tor client.

### Rust
- `proxy` field on `Coin` struct with `set_proxy()` method
- `connect_over_proxy()`, `open_proxied_stream()`, `http_connect_tunnel()` — supports socks5://, socks5h://, http://, https://
- Precedence in `client()`: Arti Tor > external proxy > direct
- Zebra full-node JSON-RPC routed through proxy
- `tokio-socks` dependency + reqwest socks feature

### Dart
- `proxy` field in `AppSettings` model, persisted to DB props
- Proxy text field + Arti Tor toggle button in Settings UI
- Proxy field greys out when Arti is enabled
- Tor SVG icon asset
- `setProxy()` wired on database open and settings save