### PR TITLE
feat: add multi-currency support

### DIFF
--- a/lib/pages/account.dart
+++ b/lib/pages/account.dart
@@ -25,6 +25,7 @@ import 'package:zkool/src/rust/api/zsa.dart';
 import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
 import 'package:zkool/widgets/error_display.dart';
+import 'package:zkool/widgets/exchange_rate.dart';
 import 'package:zkool/widgets/pool_select.dart';
 import 'package:zkool/widgets/theme.dart';
 
@@ -228,9 +229,11 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
           }
 
           final b = account.balance.field0;
+          final settings = ref.read(appSettingsProvider).requireValue;
+          final currency = settings.currency;
           final fiat = fullData.price?.let((p) {
             final f = (b[0] + b[1] + b[2]).toDouble() * p / zatsPerZec.toDouble();
-            return "\$ ${fiatFormatter.format(f)}";
+            return formatFiat(f, currency);
           });
 
           final t = Theme.of(context);
@@ -272,6 +275,8 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
                                           style: tt.displaySmall!,
                                         ),
                                         if (fiat != null) Text(fiat),
+                                        const Gap(4),
+                                        const ExchangeRateButton(),
                                       ]),
                                     ),
                                     Gap(8),
@@ -330,7 +335,7 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
         await confirmDialog(context, title: "Fetch Tx Market Price", message: "Do you want to retrieve historical ZEC prices for your past transactions?");
     if (confirmed) {
       try {
-        await fillMissingTxPrices(c: c, api: settings.coingecko);
+        await fillMissingTxPrices(c: c, api: settings.coingecko, currency: settings.currency);
       } on AnyhowException catch (e) {
         if (mounted) await showException(context, e.message);
       }

--- a/lib/pages/accounts.dart
+++ b/lib/pages/accounts.dart
@@ -16,6 +16,7 @@ import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
 import 'package:zkool/widgets/error_display.dart';
 import 'package:zkool/widgets/editable_list.dart';
+import 'package:zkool/widgets/exchange_rate.dart';
 import 'package:zkool/widgets/theme.dart';
 
 final heightID = GlobalKey();
@@ -65,7 +66,7 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
       currentHeight.setHeight(height);
       if (fetchPrice) {
         final currentPrice = ref.read(priceProvider.notifier);
-        await currentPrice.fetch(settings.coingecko);
+        await currentPrice.fetch(settings.coingecko, settings.currency);
       }
     } on AnyhowException catch (e) {
       if (mounted) await showException(context, e.message);
@@ -118,7 +119,8 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
                 ),
               ),
               const Gap(8),
-              if (pageData.price != null) ElevatedButton(onPressed: !Platform.isLinux ? onPrice : null, child: Text("Price: ${pageData.price} USD")),
+              if (pageData.price != null)
+                ExchangeRateButton(),
               const Gap(8),
               if (pageData.settings.offline) ...[
                 Text("Wallet is in offline mode", style: tt.labelSmall),
@@ -127,9 +129,10 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
             ],
             builder: (context, index, account, {selected, onSelectChanged}) {
               final avatar = account.avatar(selected: selected ?? false, onTap: onSelectChanged);
+              final currency = pageData.settings.currency;
               final fiat = pageData.price?.let((p) {
                 final f = account.balance.toDouble() * p / zatsPerZec.toDouble();
-                return fiatFormatter.format(f);
+                return formatFiat(f, currency);
               });
               return Material(
                 key: ValueKey(account.id),
@@ -146,7 +149,7 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
                         leading: account.id == 1 ? Showcase(key: avatarID, description: "Tap to select for edit/delete", child: avatar) : avatar,
                         name: account.name,
                         balance: zatToText(account.balance, selectable: false, style: tt.titleLarge!.copyWith(fontWeight: FontWeight.w700)),
-                        fiat: fiat != null ? Text("\$$fiat", style: tt.titleSmall!.copyWith(color: Colors.green)) : null,
+                        fiat: fiat != null ? Text(fiat, style: tt.titleSmall!.copyWith(color: Colors.green)) : null,
                         height: SmallProgressWidget(account, style: tt.labelSmall),
                       ),
                       onTap: () => onOpen(context, account),

--- a/lib/pages/currency.dart
+++ b/lib/pages/currency.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zkool/main.dart';
+import 'package:zkool/src/rust/api/network.dart';
+import 'package:zkool/src/rust/api/transaction.dart';
+import 'package:zkool/store.dart';
+import 'package:zkool/widgets/error_display.dart';
+
+typedef CurrencyCallback = void Function(String newCurrency);
+
+class CurrencyPage extends ConsumerStatefulWidget {
+  final CurrencyCallback onClose;
+  const CurrencyPage({required this.onClose, super.key});
+
+  @override
+  ConsumerState<CurrencyPage> createState() => _CurrencyPageState();
+}
+
+class _CurrencyPageState extends ConsumerState<CurrencyPage> {
+  late final String _originalCurrency;
+  late String _selectedCurrency;
+  bool _handlingPop = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = ref.read(appSettingsProvider).requireValue;
+    _originalCurrency = settings.currency;
+    _selectedCurrency = _originalCurrency;
+  }
+
+  Future<bool> _onPopInvoked() async {
+    if (_selectedCurrency == _originalCurrency) {
+      return true; // no change, allow pop
+    }
+
+    if (_handlingPop) return false;
+    _handlingPop = true;
+
+    final settings = ref.read(appSettingsProvider).requireValue;
+    final c = coinContext.coin;
+
+    // Try to fetch the current exchange rate for pre-fill
+    double? prefilledRate;
+    try {
+      final rate = await getExchangeRate(
+        api: settings.coingecko,
+        fromCurrency: _originalCurrency,
+        toCurrency: _selectedCurrency,
+      );
+      prefilledRate = rate.toPrice / rate.fromPrice;
+    } catch (_) {
+      // API failed — user will enter manually
+    }
+
+    if (!mounted) {
+      _handlingPop = false;
+      return false;
+    }
+
+    final exchangeRate = await _showExchangeRateDialog(
+      fromCurrency: _originalCurrency.toUpperCase(),
+      toCurrency: _selectedCurrency.toUpperCase(),
+      prefilledRate: prefilledRate,
+    );
+
+    if (!mounted) {
+      _handlingPop = false;
+      return false;
+    }
+
+    if (exchangeRate == null) {
+      // User cancelled — restore original selection, stay on page
+      setState(() {
+        _selectedCurrency = _originalCurrency;
+        _handlingPop = false;
+      });
+      return false;
+    }
+
+    // User confirmed — update historical prices
+    try {
+      await updateHistoricalPrices(
+        currency: _selectedCurrency,
+        exchangeRate: exchangeRate,
+        c: c,
+      );
+    } on AnyhowException catch (e) {
+      if (mounted) await showException(context, e.message);
+      _handlingPop = false;
+      return false;
+    }
+
+    // Persist and allow pop
+    widget.onClose(_selectedCurrency);
+    _handlingPop = false;
+    return true;
+  }
+
+  Future<double?> _showExchangeRateDialog({
+    required String fromCurrency,
+    required String toCurrency,
+    required double? prefilledRate,
+  }) async {
+    final controller = TextEditingController(
+      text: prefilledRate?.toStringAsFixed(6) ?? '',
+    );
+    final formKey = GlobalKey<FormState>();
+
+    return showDialog<double>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        title: Text('Convert Prices'),
+        content: Form(
+          key: formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'You are changing currency from $fromCurrency to $toCurrency. '
+                'All historical transaction prices need to be converted.',
+              ),
+              const Gap(16),
+              Text('How many $toCurrency per 1 $fromCurrency?'),
+              const Gap(8),
+              TextFormField(
+                controller: controller,
+                keyboardType: TextInputType.numberWithOptions(decimal: true),
+                autofocus: true,
+                decoration: InputDecoration(
+                  labelText: 'Exchange Rate',
+                  hintText: 'e.g. 0.92',
+                  suffixText: '$toCurrency / $fromCurrency',
+                ),
+                validator: (v) {
+                  if (v == null || v.isEmpty) return 'Required';
+                  final r = double.tryParse(v);
+                  if (r == null) return 'Must be a number';
+                  if (r <= 0) return 'Must be greater than 0';
+                  return null;
+                },
+              ),
+              if (prefilledRate == null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Could not fetch current rate. Please enter manually.',
+                    style: TextStyle(color: Colors.orange, fontSize: 12),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(null),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                Navigator.of(context).pop(double.parse(controller.text));
+              }
+            },
+            child: const Text('Convert'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currenciesAV = ref.watch(supportedCurrenciesProvider);
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return; // already popped
+        final shouldPop = await _onPopInvoked();
+        if (shouldPop && mounted) {
+          GoRouter.of(context).pop();
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Select Currency'),
+        ),
+        body: currenciesAV.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stack) => Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Failed to load currencies'),
+                const Gap(8),
+                Text(error.toString(), style: TextStyle(fontSize: 12, color: Colors.red)),
+                const Gap(8),
+                ElevatedButton(
+                  onPressed: () => ref.invalidate(supportedCurrenciesProvider),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+          data: (currencies) {
+            // Sort alphabetically
+            final sorted = List<String>.from(currencies)..sort();
+
+            return ListView.builder(
+              itemCount: sorted.length,
+              itemBuilder: (context, index) {
+                final currency = sorted[index];
+                final isSelected = currency == _selectedCurrency;
+
+                return ListTile(
+                  title: Text(currency.toUpperCase()),
+                  trailing: isSelected ? const Icon(Icons.check, color: Colors.green) : null,
+                  selected: isSelected,
+                  selectedTileColor: Theme.of(context).colorScheme.primaryContainer.withAlpha(100),
+                  onTap: () {
+                    setState(() => _selectedCurrency = currency);
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -7,6 +7,7 @@ import 'package:zkool/pages/category.dart';
 import 'package:zkool/pages/folder.dart';
 import 'package:zkool/pages/account.dart';
 import 'package:zkool/pages/accounts.dart';
+import 'package:zkool/pages/currency.dart';
 import 'package:zkool/pages/db.dart';
 import 'package:zkool/pages/disclaimer.dart';
 import 'package:zkool/pages/dkg.dart';
@@ -111,6 +112,10 @@ GoRouter router(bool disclaimerAccepted, bool recoveryMode) => GoRouter(
               GoRoute(path: 'theme', builder: (context, state) {
                 final onClose = state.extra as void Function((String, bool));
                 return SettingsThemePage(onClose: onClose);
+              }),
+              GoRoute(path: 'currency', builder: (context, state) {
+                final onClose = state.extra as void Function(String);
+                return CurrencyPage(onClose: onClose);
               }),
             ],
             builder: (context, state) => SettingsPage()),

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -97,8 +97,9 @@ class SettingsPageState extends ConsumerState<SettingsPage> with RouteAware {
         await prefs.setBool("expert_mode", settings.expertMode);
         await prefs.setString("palette_name", settings.paletteName);
         await prefs.setBool("dark_mode", settings.darkMode);
+        await putProp(key: "currency", value: settings.currency, c: c);
         coinContext.set(coin: c);
-        ref.read(priceProvider.notifier).setAutoFetchFx(settings.getFx, settings.coingecko);
+        ref.read(priceProvider.notifier).setAutoFetchFx(settings.getFx, settings.coingecko, settings.currency);
         ref.invalidate(appSettingsProvider);
       },
     );
@@ -316,6 +317,18 @@ class SettingsFormState extends ConsumerState<SettingsForm> {
                   ),
                 ),
                 Gap(8),
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onCurrency,
+                  child: Row(
+                    children: [
+                      Expanded(child: Text("Currency")),
+                      Text(settings.currency.toUpperCase()),
+                      Icon(Icons.chevron_right),
+                    ],
+                  ),
+                ),
+                Gap(8),
                 Showcase(
                   key: blockExplorerID,
                   description: "Block Explorer URL",
@@ -453,6 +466,15 @@ class SettingsFormState extends ConsumerState<SettingsForm> {
       final (paletteName, darkMode) = v;
       setState(() {
         settings = settings.copyWith(paletteName: paletteName, darkMode: darkMode);
+        widget.onChanged(settings);
+      });
+    });
+  }
+
+  onCurrency() async {
+    await GoRouter.of(context).push("/settings/currency", extra: (String newCurrency) {
+      setState(() {
+        settings = settings.copyWith(currency: newCurrency);
         widget.onChanged(settings);
       });
     });

--- a/lib/src/rust/api/network.dart
+++ b/lib/src/rust/api/network.dart
@@ -9,8 +9,8 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'network.freezed.dart';
 
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `Usd`, `ZcashUSD`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `coingecko_client`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `fmt`, `fmt`
 
 Future<void> initDatadir({required String directory}) =>
     RustLib.instance.api.crateApiNetworkInitDatadir(directory: directory);
@@ -18,14 +18,39 @@ Future<void> initDatadir({required String directory}) =>
 Future<int> getCurrentHeight({required Coin c}) =>
     RustLib.instance.api.crateApiNetworkGetCurrentHeight(c: c);
 
-Future<double> getCoingeckoPrice({required String api}) =>
-    RustLib.instance.api.crateApiNetworkGetCoingeckoPrice(api: api);
+Future<double> getCoingeckoPrice(
+        {required String api, required String currency}) =>
+    RustLib.instance.api
+        .crateApiNetworkGetCoingeckoPrice(api: api, currency: currency);
+
+Future<List<String>> getSupportedVsCurrencies({required String api}) =>
+    RustLib.instance.api.crateApiNetworkGetSupportedVsCurrencies(api: api);
+
+/// Returns the ZEC price in both `from_currency` and `to_currency`.
+/// The exchange rate from `from_currency` to `to_currency` can be computed as
+/// `to_price / from_price`.
+Future<ExchangeRate> getExchangeRate(
+        {required String api,
+        required String fromCurrency,
+        required String toCurrency}) =>
+    RustLib.instance.api.crateApiNetworkGetExchangeRate(
+        api: api, fromCurrency: fromCurrency, toCurrency: toCurrency);
 
 Future<String> getNetworkName({required Coin c}) =>
     RustLib.instance.api.crateApiNetworkGetNetworkName(c: c);
 
 Future<List<LWDInfo>> queryLwdList() =>
     RustLib.instance.api.crateApiNetworkQueryLwdList();
+
+@freezed
+sealed class ExchangeRate with _$ExchangeRate {
+  const factory ExchangeRate({
+    required double fromPrice,
+    required double toPrice,
+    required String fromCurrency,
+    required String toCurrency,
+  }) = _ExchangeRate;
+}
 
 @freezed
 sealed class LWDInfo with _$LWDInfo {

--- a/lib/src/rust/api/network.freezed.dart
+++ b/lib/src/rust/api/network.freezed.dart
@@ -13,6 +13,362 @@ part of 'network.dart';
 T _$identity<T>(T value) => value;
 
 /// @nodoc
+mixin _$ExchangeRate {
+  double get fromPrice;
+  double get toPrice;
+  String get fromCurrency;
+  String get toCurrency;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ExchangeRateCopyWith<ExchangeRate> get copyWith =>
+      _$ExchangeRateCopyWithImpl<ExchangeRate>(
+          this as ExchangeRate, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ExchangeRate &&
+            (identical(other.fromPrice, fromPrice) ||
+                other.fromPrice == fromPrice) &&
+            (identical(other.toPrice, toPrice) || other.toPrice == toPrice) &&
+            (identical(other.fromCurrency, fromCurrency) ||
+                other.fromCurrency == fromCurrency) &&
+            (identical(other.toCurrency, toCurrency) ||
+                other.toCurrency == toCurrency));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, fromPrice, toPrice, fromCurrency, toCurrency);
+
+  @override
+  String toString() {
+    return 'ExchangeRate(fromPrice: $fromPrice, toPrice: $toPrice, fromCurrency: $fromCurrency, toCurrency: $toCurrency)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ExchangeRateCopyWith<$Res> {
+  factory $ExchangeRateCopyWith(
+          ExchangeRate value, $Res Function(ExchangeRate) _then) =
+      _$ExchangeRateCopyWithImpl;
+  @useResult
+  $Res call(
+      {double fromPrice,
+      double toPrice,
+      String fromCurrency,
+      String toCurrency});
+}
+
+/// @nodoc
+class _$ExchangeRateCopyWithImpl<$Res> implements $ExchangeRateCopyWith<$Res> {
+  _$ExchangeRateCopyWithImpl(this._self, this._then);
+
+  final ExchangeRate _self;
+  final $Res Function(ExchangeRate) _then;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? fromPrice = null,
+    Object? toPrice = null,
+    Object? fromCurrency = null,
+    Object? toCurrency = null,
+  }) {
+    return _then(_self.copyWith(
+      fromPrice: null == fromPrice
+          ? _self.fromPrice
+          : fromPrice // ignore: cast_nullable_to_non_nullable
+              as double,
+      toPrice: null == toPrice
+          ? _self.toPrice
+          : toPrice // ignore: cast_nullable_to_non_nullable
+              as double,
+      fromCurrency: null == fromCurrency
+          ? _self.fromCurrency
+          : fromCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      toCurrency: null == toCurrency
+          ? _self.toCurrency
+          : toCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ExchangeRate].
+extension ExchangeRatePatterns on ExchangeRate {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ExchangeRate value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ExchangeRate value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate():
+        return $default(_that);
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ExchangeRate value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(double fromPrice, double toPrice, String fromCurrency,
+            String toCurrency)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that.fromPrice, _that.toPrice, _that.fromCurrency,
+            _that.toCurrency);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(double fromPrice, double toPrice, String fromCurrency,
+            String toCurrency)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate():
+        return $default(_that.fromPrice, _that.toPrice, _that.fromCurrency,
+            _that.toCurrency);
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(double fromPrice, double toPrice, String fromCurrency,
+            String toCurrency)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that.fromPrice, _that.toPrice, _that.fromCurrency,
+            _that.toCurrency);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _ExchangeRate implements ExchangeRate {
+  const _ExchangeRate(
+      {required this.fromPrice,
+      required this.toPrice,
+      required this.fromCurrency,
+      required this.toCurrency});
+
+  @override
+  final double fromPrice;
+  @override
+  final double toPrice;
+  @override
+  final String fromCurrency;
+  @override
+  final String toCurrency;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExchangeRateCopyWith<_ExchangeRate> get copyWith =>
+      __$ExchangeRateCopyWithImpl<_ExchangeRate>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ExchangeRate &&
+            (identical(other.fromPrice, fromPrice) ||
+                other.fromPrice == fromPrice) &&
+            (identical(other.toPrice, toPrice) || other.toPrice == toPrice) &&
+            (identical(other.fromCurrency, fromCurrency) ||
+                other.fromCurrency == fromCurrency) &&
+            (identical(other.toCurrency, toCurrency) ||
+                other.toCurrency == toCurrency));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, fromPrice, toPrice, fromCurrency, toCurrency);
+
+  @override
+  String toString() {
+    return 'ExchangeRate(fromPrice: $fromPrice, toPrice: $toPrice, fromCurrency: $fromCurrency, toCurrency: $toCurrency)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ExchangeRateCopyWith<$Res>
+    implements $ExchangeRateCopyWith<$Res> {
+  factory _$ExchangeRateCopyWith(
+          _ExchangeRate value, $Res Function(_ExchangeRate) _then) =
+      __$ExchangeRateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {double fromPrice,
+      double toPrice,
+      String fromCurrency,
+      String toCurrency});
+}
+
+/// @nodoc
+class __$ExchangeRateCopyWithImpl<$Res>
+    implements _$ExchangeRateCopyWith<$Res> {
+  __$ExchangeRateCopyWithImpl(this._self, this._then);
+
+  final _ExchangeRate _self;
+  final $Res Function(_ExchangeRate) _then;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? fromPrice = null,
+    Object? toPrice = null,
+    Object? fromCurrency = null,
+    Object? toCurrency = null,
+  }) {
+    return _then(_ExchangeRate(
+      fromPrice: null == fromPrice
+          ? _self.fromPrice
+          : fromPrice // ignore: cast_nullable_to_non_nullable
+              as double,
+      toPrice: null == toPrice
+          ? _self.toPrice
+          : toPrice // ignore: cast_nullable_to_non_nullable
+              as double,
+      fromCurrency: null == fromCurrency
+          ? _self.fromCurrency
+          : fromCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      toCurrency: null == toCurrency
+          ? _self.toCurrency
+          : toCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
 mixin _$LWDInfo {
   String get url;
   bool get isTor;

--- a/lib/src/rust/api/transaction.dart
+++ b/lib/src/rust/api/transaction.dart
@@ -7,8 +7,17 @@ import '../frb_generated.dart';
 import 'coin.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-Future<void> fillMissingTxPrices({required String api, required Coin c}) =>
-    RustLib.instance.api.crateApiTransactionFillMissingTxPrices(api: api, c: c);
+Future<void> fillMissingTxPrices(
+        {required String api, required String currency, required Coin c}) =>
+    RustLib.instance.api.crateApiTransactionFillMissingTxPrices(
+        api: api, currency: currency, c: c);
+
+Future<void> updateHistoricalPrices(
+        {required String currency,
+        required double exchangeRate,
+        required Coin c}) =>
+    RustLib.instance.api.crateApiTransactionUpdateHistoricalPrices(
+        currency: currency, exchangeRate: exchangeRate, c: c);
 
 Future<void> setTxCategory({required int id, int? category, required Coin c}) =>
     RustLib.instance.api

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -89,7 +89,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -126677031;
+  int get rustContentHash => -574329995;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -240,7 +240,7 @@ abstract class RustLibApi extends BaseApi {
       {required int account, required Coin c});
 
   Future<void> crateApiTransactionFillMissingTxPrices(
-      {required String api, required Coin c});
+      {required String api, required String currency, required Coin c});
 
   Future<FrostSignParams> crateApiFrostFrostSignParamsDefault();
 
@@ -270,13 +270,19 @@ abstract class RustLibApi extends BaseApi {
   Future<Addresses> crateApiAccountGetAddresses(
       {required int uaPools, required Coin c});
 
-  Future<double> crateApiNetworkGetCoingeckoPrice({required String api});
+  Future<double> crateApiNetworkGetCoingeckoPrice(
+      {required String api, required String currency});
 
   Future<int> crateApiNetworkGetCurrentHeight({required Coin c});
 
   Future<SyncHeight> crateApiSyncGetDbHeight({required Coin c});
 
   Future<List<String>> crateApiFrostGetDkgAddresses({required Coin c});
+
+  Future<ExchangeRate> crateApiNetworkGetExchangeRate(
+      {required String api,
+      required String fromCurrency,
+      required String toCurrency});
 
   Future<String> crateApiAccountGetExportedData(
       {required int type, required Coin c});
@@ -291,6 +297,9 @@ abstract class RustLibApi extends BaseApi {
   Future<String?> crateApiDbGetProp({required String key, required Coin c});
 
   Uint8List crateApiRaptorGetQrBytes({required List<int> data});
+
+  Future<List<String>> crateApiNetworkGetSupportedVsCurrencies(
+      {required String api});
 
   Future<void> crateApiCoinGetTorClient();
 
@@ -488,6 +497,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiAccountUpdateAccount(
       {required AccountUpdate update, required Coin c});
+
+  Future<void> crateApiTransactionUpdateHistoricalPrices(
+      {required String currency,
+      required double exchangeRate,
+      required Coin c});
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_DartVault;
@@ -1811,12 +1825,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> crateApiTransactionFillMissingTxPrices(
-      {required String api, required Coin c}) {
+      {required String api, required String currency, required Coin c}) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(api, serializer);
+          sse_encode_String(currency, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
               funcId: 44, port: port_);
@@ -1826,7 +1841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiTransactionFillMissingTxPricesConstMeta,
-        argValues: [api, c],
+        argValues: [api, currency, c],
         apiImpl: this,
       ),
     );
@@ -1835,7 +1850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiTransactionFillMissingTxPricesConstMeta =>
       const TaskConstMeta(
         debugName: "fill_missing_tx_prices",
-        argNames: ["api", "c"],
+        argNames: ["api", "currency", "c"],
       );
 
   @override
@@ -2146,12 +2161,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<double> crateApiNetworkGetCoingeckoPrice({required String api}) {
+  Future<double> crateApiNetworkGetCoingeckoPrice(
+      {required String api, required String currency}) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(api, serializer);
+          sse_encode_String(currency, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
               funcId: 56, port: port_);
         },
@@ -2160,7 +2177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiNetworkGetCoingeckoPriceConstMeta,
-        argValues: [api],
+        argValues: [api, currency],
         apiImpl: this,
       ),
     );
@@ -2169,7 +2186,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiNetworkGetCoingeckoPriceConstMeta =>
       const TaskConstMeta(
         debugName: "get_coingecko_price",
-        argNames: ["api"],
+        argNames: ["api", "currency"],
       );
 
   @override
@@ -2253,6 +2270,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<ExchangeRate> crateApiNetworkGetExchangeRate(
+      {required String api,
+      required String fromCurrency,
+      required String toCurrency}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(api, serializer);
+          sse_encode_String(fromCurrency, serializer);
+          sse_encode_String(toCurrency, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer,
+              funcId: 60, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_exchange_rate,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiNetworkGetExchangeRateConstMeta,
+        argValues: [api, fromCurrency, toCurrency],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkGetExchangeRateConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_exchange_rate",
+        argNames: ["api", "fromCurrency", "toCurrency"],
+      );
+
+  @override
   Future<String> crateApiAccountGetExportedData(
       {required int type, required Coin c}) {
     return handler.executeNormal(
@@ -2262,7 +2311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_8(type, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 60, port: port_);
+              funcId: 61, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2289,7 +2338,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -2317,7 +2366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(txId, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 62, port: port_);
+              funcId: 63, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2344,7 +2393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 63, port: port_);
+              funcId: 64, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2372,7 +2421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 64, port: port_);
+              funcId: 65, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -2397,7 +2446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2416,13 +2465,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<List<String>> crateApiNetworkGetSupportedVsCurrencies(
+      {required String api}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(api, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer,
+              funcId: 67, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiNetworkGetSupportedVsCurrenciesConstMeta,
+        argValues: [api],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkGetSupportedVsCurrenciesConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_supported_vs_currencies",
+        argNames: ["api"],
+      );
+
+  @override
   Future<void> crateApiCoinGetTorClient() {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 66, port: port_);
+              funcId: 68, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2450,7 +2527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(idTx, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 67, port: port_);
+              funcId: 69, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_account,
@@ -2477,7 +2554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 68, port: port_);
+              funcId: 70, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2504,7 +2581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 69, port: port_);
+              funcId: 71, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2530,7 +2607,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 70, port: port_);
+              funcId: 72, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2560,7 +2637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_8_loose(data, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 71, port: port_);
+              funcId: 73, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2586,7 +2663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 72, port: port_);
+              funcId: 74, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2611,7 +2688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 73, port: port_);
+              funcId: 75, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2637,7 +2714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(directory, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 74, port: port_);
+              funcId: 76, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2663,7 +2740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(directory, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 75, port: port_);
+              funcId: 77, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2689,7 +2766,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 76, port: port_);
+              funcId: 78, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2722,7 +2799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 77, port: port_);
+              funcId: 79, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2750,7 +2827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_DartFn_Inputs_list_prim_u_8_strict_Output_unit_AnyhowException(
               append, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 78, port: port_);
+              funcId: 80, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2777,7 +2854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 79, port: port_);
+              funcId: 81, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2804,7 +2881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2829,7 +2906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2855,7 +2932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(fvk, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2881,7 +2958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(key, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2906,7 +2983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(phrase, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2933,7 +3010,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2973,7 +3050,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(idAccount, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 86, port: port_);
+              funcId: 88, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -3015,7 +3092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 87, port: port_);
+              funcId: 89, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_account,
@@ -3042,7 +3119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 88, port: port_);
+              funcId: 90, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_category,
@@ -3069,7 +3146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dir, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 89, port: port_);
+              funcId: 91, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3095,7 +3172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 90, port: port_);
+              funcId: 92, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_folder,
@@ -3121,7 +3198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 91, port: port_);
+              funcId: 93, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_memo,
@@ -3147,7 +3224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 92, port: port_);
+              funcId: 94, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_tx_note,
@@ -3173,7 +3250,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 93, port: port_);
+              funcId: 95, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_tx,
@@ -3200,7 +3277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 94, port: port_);
+              funcId: 96, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_zsa_holding,
@@ -3229,7 +3306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(locked, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 95, port: port_);
+              funcId: 97, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3258,7 +3335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(threshold, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 96, port: port_);
+              funcId: 98, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3285,7 +3362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 97, port: port_);
+              funcId: 99, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -3314,7 +3391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_new_account(na, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 98, port: port_);
+              funcId: 100, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -3340,7 +3417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 99, port: port_);
+              funcId: 101, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -3366,7 +3443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(uri, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 100)!;
+              funcId: 102)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_list_recipient,
@@ -3397,7 +3474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_payment_options(options, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 101, port: port_);
+              funcId: 103, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -3424,7 +3501,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(id, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 102, port: port_);
+              funcId: 104, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3453,7 +3530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(value, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 103, port: port_);
+              funcId: 105, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3478,7 +3555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 104, port: port_);
+              funcId: 106, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_lwd_info,
@@ -3504,7 +3581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 105, port: port_);
+              funcId: 107, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_receivers,
@@ -3533,7 +3610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ua, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 106)!;
+              funcId: 108)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_receivers,
@@ -3562,7 +3639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(accountId, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 107, port: port_);
+              funcId: 109, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3591,7 +3668,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_category(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 108, port: port_);
+              funcId: 110, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3621,7 +3698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 109, port: port_);
+              funcId: 111, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3651,7 +3728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(newPosition, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 110, port: port_);
+              funcId: 112, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3678,7 +3755,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 111, port: port_);
+              funcId: 113, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3705,7 +3782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(id, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 112, port: port_);
+              funcId: 114, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3734,7 +3811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(account, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 113, port: port_);
+              funcId: 115, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3763,7 +3840,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_list_prim_u_8_loose(data, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 114, port: port_);
+              funcId: 116, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3792,7 +3869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 115, port: port_);
+              funcId: 117, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3821,7 +3898,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(address, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 116, port: port_);
+              funcId: 118, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3858,7 +3935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(fundingAccount, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 117, port: port_);
+              funcId: 119, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3885,7 +3962,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_StreamSink_log_message_Sse(s, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 118)!;
+              funcId: 120)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3915,7 +3992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 119, port: port_);
+              funcId: 121, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3945,7 +4022,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_f_64(price, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 120, port: port_);
+              funcId: 122, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3972,7 +4049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 121, port: port_);
+              funcId: 123, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4000,7 +4077,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 122, port: port_);
+              funcId: 124, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4032,7 +4109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_box_autoadd_pczt_package(package, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 123, port: port_);
+                funcId: 125, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -4063,7 +4140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(pczt, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 124, port: port_);
+              funcId: 126, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -4098,7 +4175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(category, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 125, port: port_);
+              funcId: 127, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4140,7 +4217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_bool(fast, serializer);
             sse_encode_box_autoadd_coin(c, serializer);
             pdeCallFfi(generalizedFrbRustBinding, serializer,
-                funcId: 126, port: port_);
+                funcId: 128, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_u_32,
@@ -4187,7 +4264,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_pczt_package(package, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 127)!;
+              funcId: 129)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_plan,
@@ -4212,7 +4289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 128, port: port_);
+              funcId: 130, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_account,
@@ -4238,7 +4315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 129, port: port_);
+              funcId: 131, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_memo,
@@ -4264,7 +4341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 130, port: port_);
+              funcId: 132, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_note,
@@ -4290,7 +4367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 131, port: port_);
+              funcId: 133, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_output,
@@ -4316,7 +4393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 132, port: port_);
+              funcId: 134, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tx_spend,
@@ -4346,7 +4423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_32(di, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 133)!;
+              funcId: 135)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4372,7 +4449,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 134, port: port_);
+              funcId: 136, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4399,7 +4476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(bytes, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 135, port: port_);
+              funcId: 137, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_pczt_package,
@@ -4428,7 +4505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_box_autoadd_account_update(update, serializer);
           sse_encode_box_autoadd_coin(c, serializer);
           pdeCallFfi(generalizedFrbRustBinding, serializer,
-              funcId: 136, port: port_);
+              funcId: 138, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4445,6 +4522,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "update_account",
         argNames: ["update", "c"],
+      );
+
+  @override
+  Future<void> crateApiTransactionUpdateHistoricalPrices(
+      {required String currency,
+      required double exchangeRate,
+      required Coin c}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(currency, serializer);
+          sse_encode_f_64(exchangeRate, serializer);
+          sse_encode_box_autoadd_coin(c, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer,
+              funcId: 139, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiTransactionUpdateHistoricalPricesConstMeta,
+        argValues: [currency, exchangeRate, c],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiTransactionUpdateHistoricalPricesConstMeta =>
+      const TaskConstMeta(
+        debugName: "update_historical_prices",
+        argNames: ["currency", "exchangeRate", "c"],
       );
 
   Future<void> Function(int, dynamic)
@@ -4892,6 +5001,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       default:
         throw Exception("unreachable");
     }
+  }
+
+  @protected
+  ExchangeRate dco_decode_exchange_rate(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return ExchangeRate(
+      fromPrice: dco_decode_f_64(arr[0]),
+      toPrice: dco_decode_f_64(arr[1]),
+      fromCurrency: dco_decode_String(arr[2]),
+      toCurrency: dco_decode_String(arr[3]),
+    );
   }
 
   @protected
@@ -6198,6 +6321,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       default:
         throw UnimplementedError('');
     }
+  }
+
+  @protected
+  ExchangeRate sse_decode_exchange_rate(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_fromPrice = sse_decode_f_64(deserializer);
+    var var_toPrice = sse_decode_f_64(deserializer);
+    var var_fromCurrency = sse_decode_String(deserializer);
+    var var_toCurrency = sse_decode_String(deserializer);
+    return ExchangeRate(
+        fromPrice: var_fromPrice,
+        toPrice: var_toPrice,
+        fromCurrency: var_fromCurrency,
+        toCurrency: var_toCurrency);
   }
 
   @protected
@@ -7743,6 +7880,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(7, serializer);
         sse_encode_String(field0, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_exchange_rate(ExchangeRate self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.fromPrice, serializer);
+    sse_encode_f_64(self.toPrice, serializer);
+    sse_encode_String(self.fromCurrency, serializer);
+    sse_encode_String(self.toCurrency, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -210,6 +210,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DKGStatus dco_decode_dkg_status(dynamic raw);
 
   @protected
+  ExchangeRate dco_decode_exchange_rate(dynamic raw);
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -636,6 +639,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   DKGStatus sse_decode_dkg_status(SseDeserializer deserializer);
+
+  @protected
+  ExchangeRate sse_decode_exchange_rate(SseDeserializer deserializer);
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
@@ -1082,6 +1088,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_dkg_status(DKGStatus self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_exchange_rate(ExchangeRate self, SseSerializer serializer);
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -212,6 +212,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DKGStatus dco_decode_dkg_status(dynamic raw);
 
   @protected
+  ExchangeRate dco_decode_exchange_rate(dynamic raw);
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -638,6 +641,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   DKGStatus sse_decode_dkg_status(SseDeserializer deserializer);
+
+  @protected
+  ExchangeRate sse_decode_exchange_rate(SseDeserializer deserializer);
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
@@ -1084,6 +1090,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_dkg_status(DKGStatus self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_exchange_rate(ExchangeRate self, SseSerializer serializer);
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);

--- a/lib/store.dart
+++ b/lib/store.dart
@@ -349,12 +349,13 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
       delay: int.parse(qrDelay),
       repair: int.parse(qrRepair),
     );
-    final price = ref.watch(priceProvider.notifier);
-    price.setAutoFetchFx(getFx, coingecko);
     final vault = await prefs.getBool("vault") ?? false;
     final expertMode = await prefs.getBool("expert_mode") ?? false;
     final paletteName = await prefs.getString("palette_name") ?? 'blue';
     final darkMode = await prefs.getBool("dark_mode") ?? true;
+    final currency = (hasDb ? await getProp(key: "currency", c: c) : null) ?? "usd";
+    final price = ref.watch(priceProvider.notifier);
+    price.setAutoFetchFx(getFx, coingecko, currency);
 
     return AppSettings(
       dbName: dbName,
@@ -377,6 +378,7 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
       expertMode: expertMode,
       paletteName: paletteName,
       darkMode: darkMode,
+      currency: currency,
     );
   }
 
@@ -407,11 +409,16 @@ class PriceNotifier extends _$PriceNotifier {
   }
 
   Timer? fetchFxTimer;
-  void setAutoFetchFx(bool autoGetFx, String api) async {
+  String _lastApi = "";
+  String _lastCurrency = "usd";
+
+  void setAutoFetchFx(bool autoGetFx, String api, String currency) async {
+    _lastApi = api;
+    _lastCurrency = currency;
     if (autoGetFx) {
-      await fetch(api);
+      await fetch(api, currency);
       fetchFxTimer = Timer.periodic(Duration(minutes: 1), (_) async {
-        await fetch(api);
+        await fetch(_lastApi, _lastCurrency);
       });
     } else {
       fetchFxTimer?.cancel();
@@ -419,14 +426,23 @@ class PriceNotifier extends _$PriceNotifier {
     }
   }
 
-  Future<double?> fetch(String api) async {
+  Future<double?> fetch(String api, String currency) async {
     try {
-      final p = await getCoingeckoPrice(api: api);
+      final p = await getCoingeckoPrice(api: api, currency: currency);
       setPrice(p);
       return p;
     } catch (_) {
       return null;
     }
+  }
+}
+
+@Riverpod(keepAlive: true)
+class SupportedCurrenciesNotifier extends _$SupportedCurrenciesNotifier {
+  @override
+  Future<List<String>> build() async {
+    final settings = await ref.watch(appSettingsProvider.future);
+    return await getSupportedVsCurrencies(api: settings.coingecko);
   }
 }
 
@@ -453,6 +469,7 @@ sealed class AppSettings with _$AppSettings {
     required bool expertMode,
     required String paletteName,
     required bool darkMode,
+    required String currency,
   }) = _AppSettings;
 }
 

--- a/lib/store.freezed.dart
+++ b/lib/store.freezed.dart
@@ -1345,6 +1345,7 @@ mixin _$AppSettings {
   bool get expertMode;
   String get paletteName;
   bool get darkMode;
+  String get currency;
 
   /// Create a copy of AppSettings
   /// with the given fields replaced by the non-null parameter values.
@@ -1388,7 +1389,9 @@ mixin _$AppSettings {
             (identical(other.paletteName, paletteName) ||
                 other.paletteName == paletteName) &&
             (identical(other.darkMode, darkMode) ||
-                other.darkMode == darkMode));
+                other.darkMode == darkMode) &&
+            (identical(other.currency, currency) ||
+                other.currency == currency));
   }
 
   @override
@@ -1413,12 +1416,13 @@ mixin _$AppSettings {
         vault,
         expertMode,
         paletteName,
-        darkMode
+        darkMode,
+        currency
       ]);
 
   @override
   String toString() {
-    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
+    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode, currency: $currency)';
   }
 }
 
@@ -1448,7 +1452,8 @@ abstract mixin class $AppSettingsCopyWith<$Res> {
       bool vault,
       bool expertMode,
       String paletteName,
-      bool darkMode});
+      bool darkMode,
+      String currency});
 
   $QRSettingsCopyWith<$Res> get qrSettings;
 }
@@ -1485,6 +1490,7 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
     Object? expertMode = null,
     Object? paletteName = null,
     Object? darkMode = null,
+    Object? currency = null,
   }) {
     return _then(_self.copyWith(
       dbName: null == dbName
@@ -1567,6 +1573,10 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
           ? _self.darkMode
           : darkMode // ignore: cast_nullable_to_non_nullable
               as bool,
+      currency: null == currency
+          ? _self.currency
+          : currency // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 
@@ -1692,7 +1702,8 @@ extension AppSettingsPatterns on AppSettings {
             bool vault,
             bool expertMode,
             String paletteName,
-            bool darkMode)?
+            bool darkMode,
+            String currency)?
         $default, {
     required TResult orElse(),
   }) {
@@ -1719,7 +1730,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.vault,
             _that.expertMode,
             _that.paletteName,
-            _that.darkMode);
+            _that.darkMode,
+            _that.currency);
       case _:
         return orElse();
     }
@@ -1760,7 +1772,8 @@ extension AppSettingsPatterns on AppSettings {
             bool vault,
             bool expertMode,
             String paletteName,
-            bool darkMode)
+            bool darkMode,
+            String currency)
         $default,
   ) {
     final _that = this;
@@ -1786,7 +1799,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.vault,
             _that.expertMode,
             _that.paletteName,
-            _that.darkMode);
+            _that.darkMode,
+            _that.currency);
     }
   }
 
@@ -1824,7 +1838,8 @@ extension AppSettingsPatterns on AppSettings {
             bool vault,
             bool expertMode,
             String paletteName,
-            bool darkMode)?
+            bool darkMode,
+            String currency)?
         $default,
   ) {
     final _that = this;
@@ -1850,7 +1865,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.vault,
             _that.expertMode,
             _that.paletteName,
-            _that.darkMode);
+            _that.darkMode,
+            _that.currency);
       case _:
         return null;
     }
@@ -1880,7 +1896,8 @@ class _AppSettings implements AppSettings {
       required this.vault,
       required this.expertMode,
       required this.paletteName,
-      required this.darkMode});
+      required this.darkMode,
+      required this.currency});
 
   @override
   final String dbName;
@@ -1923,6 +1940,8 @@ class _AppSettings implements AppSettings {
   final String paletteName;
   @override
   final bool darkMode;
+  @override
+  final String currency;
 
   /// Create a copy of AppSettings
   /// with the given fields replaced by the non-null parameter values.
@@ -1967,7 +1986,9 @@ class _AppSettings implements AppSettings {
             (identical(other.paletteName, paletteName) ||
                 other.paletteName == paletteName) &&
             (identical(other.darkMode, darkMode) ||
-                other.darkMode == darkMode));
+                other.darkMode == darkMode) &&
+            (identical(other.currency, currency) ||
+                other.currency == currency));
   }
 
   @override
@@ -1992,12 +2013,13 @@ class _AppSettings implements AppSettings {
         vault,
         expertMode,
         paletteName,
-        darkMode
+        darkMode,
+        currency
       ]);
 
   @override
   String toString() {
-    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode)';
+    return 'AppSettings(dbName: $dbName, net: $net, isLightNode: $isLightNode, lwd: $lwd, blockExplorer: $blockExplorer, syncInterval: $syncInterval, actionsPerSync: $actionsPerSync, useTor: $useTor, proxy: $proxy, coingecko: $coingecko, recovery: $recovery, needPin: $needPin, pinUnlockedAt: $pinUnlockedAt, offline: $offline, getFx: $getFx, qrSettings: $qrSettings, vault: $vault, expertMode: $expertMode, paletteName: $paletteName, darkMode: $darkMode, currency: $currency)';
   }
 }
 
@@ -2029,7 +2051,8 @@ abstract mixin class _$AppSettingsCopyWith<$Res>
       bool vault,
       bool expertMode,
       String paletteName,
-      bool darkMode});
+      bool darkMode,
+      String currency});
 
   @override
   $QRSettingsCopyWith<$Res> get qrSettings;
@@ -2067,6 +2090,7 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
     Object? expertMode = null,
     Object? paletteName = null,
     Object? darkMode = null,
+    Object? currency = null,
   }) {
     return _then(_AppSettings(
       dbName: null == dbName
@@ -2149,6 +2173,10 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
           ? _self.darkMode
           : darkMode // ignore: cast_nullable_to_non_nullable
               as bool,
+      currency: null == currency
+          ? _self.currency
+          : currency // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 

--- a/lib/store.g.dart
+++ b/lib/store.g.dart
@@ -505,7 +505,7 @@ final class AppSettingsNotifierProvider
 }
 
 String _$appSettingsNotifierHash() =>
-    r'a5f94ec12952b3d679b1208165f7d559434d037d';
+    r'd1c42b6c957dc4f5fab50e908bbe919f7027525a';
 
 abstract class _$AppSettingsNotifier extends $AsyncNotifier<AppSettings> {
   FutureOr<AppSettings> build();
@@ -555,7 +555,7 @@ final class PriceNotifierProvider
   }
 }
 
-String _$priceNotifierHash() => r'9c6f7b369e9fef6348fa6fdda446294b8c8dac98';
+String _$priceNotifierHash() => r'eeefd55a0163e184ab50f6725b602c5e3b08043a';
 
 abstract class _$PriceNotifier extends $Notifier<double?> {
   double? build();
@@ -566,6 +566,50 @@ abstract class _$PriceNotifier extends $Notifier<double?> {
     final ref = this.ref as $Ref<double?, double?>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<double?, double?>, double?, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}
+
+@ProviderFor(SupportedCurrenciesNotifier)
+const supportedCurrenciesProvider = SupportedCurrenciesNotifierProvider._();
+
+final class SupportedCurrenciesNotifierProvider
+    extends $AsyncNotifierProvider<SupportedCurrenciesNotifier, List<String>> {
+  const SupportedCurrenciesNotifierProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'supportedCurrenciesProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$supportedCurrenciesNotifierHash();
+
+  @$internal
+  @override
+  SupportedCurrenciesNotifier create() => SupportedCurrenciesNotifier();
+}
+
+String _$supportedCurrenciesNotifierHash() =>
+    r'6f0ef88efa8e2e0b124b8880bea1e8620df43f27';
+
+abstract class _$SupportedCurrenciesNotifier
+    extends $AsyncNotifier<List<String>> {
+  FutureOr<List<String>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<List<String>>, List<String>>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<AsyncValue<List<String>>, List<String>>,
+        AsyncValue<List<String>>,
+        Object?,
+        Object?>;
     element.handleValue(ref, created);
   }
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -45,6 +45,13 @@ final invertSeparator = NumberFormat.decimalPattern(locale).symbols.DECIMAL_SEP 
 
 final int zatsPerZec = 100000000;
 
+/// Format a fiat amount with its currency code.
+/// Uses the locale-aware number formatter followed by the uppercased currency code.
+String formatFiat(double amount, String currency) {
+  final formatted = fiatFormatter.format(amount);
+  return '$formatted ${currency.toUpperCase()}';
+}
+
 String doubleToString(double v, {required int decimals}) {
   final formatter = NumberFormat.decimalPatternDigits(locale: locale, decimalDigits: decimals);
   return formatter.format(v);

--- a/lib/widgets/exchange_rate.dart
+++ b/lib/widgets/exchange_rate.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:zkool/store.dart';
+
+/// A discreet outlined button that displays the ZEC-to-fiat exchange rate.
+/// Tapping refreshes the rate from CoinGecko.
+/// Auto-scales: "1 ZEC = 445 USD" when rate >= 1, or "100 ZEC = 1 BTC" when rate < 1.
+class ExchangeRateButton extends ConsumerWidget {
+  const ExchangeRateButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final price = ref.watch(priceProvider);
+    final settingsAV = ref.watch(appSettingsProvider);
+    final currency = settingsAV.value?.currency.toUpperCase() ?? 'USD';
+
+    if (price == null) {
+      return const SizedBox.shrink();
+    }
+
+    final label = _formatRate(price, currency);
+
+    return OutlinedButton(
+      onPressed: () => _refresh(ref),
+      style: OutlinedButton.styleFrom(
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
+        side: BorderSide(color: Theme.of(context).colorScheme.outline),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      ),
+      child: Text(label, style: Theme.of(context).textTheme.bodyMedium),
+    );
+  }
+
+  String _formatRate(double rate, String currency) {
+    if (rate >= 1.0) {
+      final formatted = rate.toStringAsFixed(2);
+      return '1 ZEC = $formatted $currency';
+    } else {
+      // Scale up: find how many ZEC per 1 unit of currency
+      final scale = (1.0 / rate).ceil();
+      return '$scale ZEC = 1 $currency';
+    }
+  }
+
+  void _refresh(WidgetRef ref) async {
+    final settings = ref.read(appSettingsProvider).value;
+    if (settings == null) return;
+    final priceNotifier = ref.read(priceProvider.notifier);
+    await priceNotifier.fetch(settings.coingecko, settings.currency);
+  }
+}

--- a/lib/widgets/input_amount.dart
+++ b/lib/widgets/input_amount.dart
@@ -38,10 +38,12 @@ class InputAmountState extends ConsumerState<InputAmount> {
 
   @override
   Widget build(BuildContext context) {
-    final coingecko = ref.watch(appSettingsProvider).whenData((s) => s.coingecko);
-    if (coingecko.value == null) return blank(context);
+    final settingsAV = ref.watch(appSettingsProvider);
+    if (!settingsAV.hasValue) return blank(context);
+    final settings = settingsAV.requireValue;
 
     final price = ref.watch(priceProvider);
+    final currency = settings.currency.toUpperCase();
     return FormBuilderField<String>(
       key: formFieldKey,
       name: widget.name,
@@ -81,7 +83,7 @@ class InputAmountState extends ConsumerState<InputAmount> {
                     Expanded(
                       child: FormBuilderTextField(
                         name: "fiat",
-                        decoration: InputDecoration(label: Text("Amount in USD")),
+                        decoration: InputDecoration(label: Text("Amount in $currency")),
                         validator: validAmount,
                         keyboardType: TextInputType.numberWithOptions(decimal: true),
                         onChanged: (v) => onFiatChanged(v, interactive: true),
@@ -101,13 +103,13 @@ class InputAmountState extends ConsumerState<InputAmount> {
                     ),
                     Gap(8),
                     IconButton(
-                      onPressed: () => onUpdateFx(coingecko.requireValue),
+                      onPressed: () => onUpdateFx(settings),
                       icon: Icon(Icons.refresh),
                     ),
                   ],
                 ),
               Gap(16),
-              if (widget.showFx) Text("The Amount in USD is indicative. The transaction is always made in crypto."),
+              if (widget.showFx) Text("The Amount in $currency is indicative. The transaction is always made in crypto."),
             ],
           ),
         );
@@ -115,8 +117,8 @@ class InputAmountState extends ConsumerState<InputAmount> {
     );
   }
 
-  void onUpdateFx(String coingecko) async {
-    final p = await getCoingeckoPrice(api: coingecko);
+  void onUpdateFx(AppSettings settings) async {
+    final p = await getCoingeckoPrice(api: settings.coingecko, currency: settings.currency);
     setState(() {
       final price = ref.read(priceProvider.notifier);
       price.setPrice(p);

--- a/rust/src/api/network.rs
+++ b/rust/src/api/network.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
 
 use crate::api::coin::Coin;
 #[cfg(feature = "flutter")]
@@ -16,14 +18,74 @@ pub async fn get_current_height(c: &Coin) -> Result<u32> {
     Ok(height as u32)
 }
 
-pub async fn get_coingecko_price(api: &str) -> Result<f64> {
-    let rep =
-        reqwest::get(&format!("https://api.coingecko.com/api/v3/simple/price?ids=zcash&vs_currencies=usd&x_cg_demo_api_key={api}"))
-            .await?
-            .error_for_status()?
-            .json::<ZcashUSD>()
-            .await?;
-    Ok(rep.zcash.usd)
+fn coingecko_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent("zkool/1.0")
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+pub async fn get_coingecko_price(api: &str, currency: &str) -> Result<f64> {
+    let rep = coingecko_client()
+        .get(&format!(
+            "https://api.coingecko.com/api/v3/simple/price?ids=zcash&vs_currencies={currency}&x_cg_demo_api_key={api}"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await?;
+    let price = rep["zcash"][currency]
+        .as_f64()
+        .ok_or(anyhow!("Price not found for currency: {currency}"))?;
+    Ok(price)
+}
+
+#[cfg_attr(feature = "flutter", frb)]
+pub async fn get_supported_vs_currencies(api: &str) -> Result<Vec<String>> {
+    let rep = coingecko_client()
+        .get(&format!(
+            "https://api.coingecko.com/api/v3/simple/supported_vs_currencies?x_cg_demo_api_key={api}"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Vec<String>>()
+        .await?;
+    Ok(rep)
+}
+
+/// Returns the ZEC price in both `from_currency` and `to_currency`.
+/// The exchange rate from `from_currency` to `to_currency` can be computed as
+/// `to_price / from_price`.
+#[cfg_attr(feature = "flutter", frb)]
+pub async fn get_exchange_rate(
+    api: &str,
+    from_currency: &str,
+    to_currency: &str,
+) -> Result<ExchangeRate> {
+    let rep = coingecko_client()
+        .get(&format!(
+            "https://api.coingecko.com/api/v3/simple/price?ids=zcash&vs_currencies={from_currency},{to_currency}&x_cg_demo_api_key={api}"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await?;
+    let from_price = rep["zcash"][from_currency]
+        .as_f64()
+        .ok_or(anyhow!("Price not found for currency: {from_currency}"))?;
+    let to_price = rep["zcash"][to_currency]
+        .as_f64()
+        .ok_or(anyhow!("Price not found for currency: {to_currency}"))?;
+    Ok(ExchangeRate {
+        from_price,
+        to_price,
+        from_currency: from_currency.to_string(),
+        to_currency: to_currency.to_string(),
+    })
 }
 
 #[cfg_attr(feature = "flutter", frb)]
@@ -36,14 +98,13 @@ pub async fn query_lwd_list() -> Result<Vec<LWDInfo>> {
     crate::net::lwd::query_lwd_list().await
 }
 
-#[derive(Deserialize)]
-struct Usd {
-    usd: f64,
-}
-
-#[derive(Deserialize)]
-struct ZcashUSD {
-    zcash: Usd,
+#[cfg_attr(feature = "flutter", frb(dart_metadata = ("freezed")))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeRate {
+    pub from_price: f64,
+    pub to_price: f64,
+    pub from_currency: String,
+    pub to_currency: String,
 }
 
 #[cfg_attr(feature = "flutter", frb(dart_metadata = ("freezed")))]

--- a/rust/src/api/transaction.rs
+++ b/rust/src/api/transaction.rs
@@ -5,9 +5,16 @@ use crate::api::coin::Coin;
 use flutter_rust_bridge::frb;
 
 #[cfg_attr(feature = "flutter", frb)]
-pub async fn fill_missing_tx_prices(api: String, c: &Coin) -> Result<()> {
+pub async fn fill_missing_tx_prices(api: String, currency: String, c: &Coin) -> Result<()> {
     let mut connection = c.get_connection().await?;
-    crate::budget::fill_missing_tx_prices(&mut connection, c.account, &api).await?;
+    crate::budget::fill_missing_tx_prices(&mut connection, c.account, &currency, &api).await?;
+    Ok(())
+}
+
+#[cfg_attr(feature = "flutter", frb)]
+pub async fn update_historical_prices(currency: String, exchange_rate: f64, c: &Coin) -> Result<()> {
+    let mut connection = c.get_connection().await?;
+    crate::budget::update_historical_prices(&mut connection, &currency, exchange_rate).await?;
     Ok(())
 }
 

--- a/rust/src/budget.rs
+++ b/rust/src/budget.rs
@@ -1,21 +1,30 @@
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 use sqlx::{sqlite::SqliteRow, Row, SqliteConnection};
+use std::time::Duration;
 
-async fn get_historical_prices_all(api: &str) -> Result<Vec<PriceQuote>> {
+fn coingecko_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent("zkool/1.0")
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+async fn get_historical_prices_all(currency: &str, api: &str) -> Result<Vec<PriceQuote>> {
     // 1, 90 and 365 are the max day ranges per interval
-    let mut pqs = get_historical_prices(1, api).await?;
-    pqs.extend(get_historical_prices(90, api).await?);
-    pqs.extend(get_historical_prices(365, api).await?);
+    let mut pqs = get_historical_prices(1, currency, api).await?;
+    pqs.extend(get_historical_prices(90, currency, api).await?);
+    pqs.extend(get_historical_prices(365, currency, api).await?);
     pqs.sort_by_key(|pq| pq.time);
     Ok(pqs)
 }
 
-async fn get_historical_prices(days: u32, api: &str) -> Result<Vec<PriceQuote>> {
+async fn get_historical_prices(days: u32, currency: &str, api: &str) -> Result<Vec<PriceQuote>> {
     let historical_price_url = format!(
-        "https://api.coingecko.com/api/v3/coins/zcash/market_chart?vs_currency=usd&days={days}&x_cg_demo_api_key={api}"
+        "https://api.coingecko.com/api/v3/coins/zcash/market_chart?vs_currency={currency}&days={days}&x_cg_demo_api_key={api}"
     );
-    let rep: Value = reqwest::get(&historical_price_url).await?.json().await?;
+    let rep: Value = coingecko_client().get(&historical_price_url).send().await?.json().await?;
     let prices = rep
         .pointer("/prices")
         .ok_or(anyhow!("No /prices"))?
@@ -91,11 +100,37 @@ pub async fn store_tx_prices(connection: &mut SqliteConnection, txs: &[TxUSD]) -
     Ok(())
 }
 
-pub async fn fill_missing_tx_prices(connection: &mut SqliteConnection, account: u32, api: &str) -> Result<()> {
+pub async fn fill_missing_tx_prices(
+    connection: &mut SqliteConnection,
+    account: u32,
+    currency: &str,
+    api: &str,
+) -> Result<()> {
     let mut txs = fetch_missing_tx_prices(&mut *connection, account).await?;
-    let pqs = get_historical_prices_all(api).await?;
+    let pqs = get_historical_prices_all(currency, api).await?;
     fill_historical_prices(&mut txs, &pqs).await?;
     store_tx_prices(&mut *connection, &txs).await?;
+    Ok(())
+}
+
+/// Recompute every transaction's price column for a currency change.
+/// `exchange_rate` is the multiplier: new_price = old_price * exchange_rate
+/// (e.g. when changing from USD to EUR at 0.92 EUR per 1 USD, exchange_rate = 0.92).
+/// The currency prop is updated in the same transaction.
+pub async fn update_historical_prices(
+    connection: &mut SqliteConnection,
+    currency: &str,
+    exchange_rate: f64,
+) -> Result<()> {
+    sqlx::query("UPDATE transactions SET price = price * ?1 WHERE price IS NOT NULL")
+        .bind(exchange_rate)
+        .execute(&mut *connection)
+        .await?;
+    // Upsert the currency prop
+    sqlx::query("INSERT OR REPLACE INTO props (key, value) VALUES ('currency', ?1)")
+        .bind(currency)
+        .execute(&mut *connection)
+        .await?;
     Ok(())
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -126677031;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -574329995;
 
 // Section: executor
 
@@ -1910,14 +1910,18 @@ fn wire__crate__api__transaction__fill_missing_tx_prices_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_api = <String>::sse_decode(&mut deserializer);
+            let api_currency = <String>::sse_decode(&mut deserializer);
             let api_c = <crate::api::coin::Coin>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
-                        let output_ok =
-                            crate::api::transaction::fill_missing_tx_prices(api_api, &api_c)
-                                .await?;
+                        let output_ok = crate::api::transaction::fill_missing_tx_prices(
+                            api_api,
+                            api_currency,
+                            &api_c,
+                        )
+                        .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2359,11 +2363,14 @@ fn wire__crate__api__network__get_coingecko_price_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_api = <String>::sse_decode(&mut deserializer);
+            let api_currency = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
-                        let output_ok = crate::api::network::get_coingecko_price(&api_api).await?;
+                        let output_ok =
+                            crate::api::network::get_coingecko_price(&api_api, &api_currency)
+                                .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2472,6 +2479,49 @@ fn wire__crate__api__frost__get_dkg_addresses_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::frost::get_dkg_addresses(&api_c).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__network__get_exchange_rate_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_exchange_rate",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_api = <String>::sse_decode(&mut deserializer);
+            let api_from_currency = <String>::sse_decode(&mut deserializer);
+            let api_to_currency = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::network::get_exchange_rate(
+                            &api_api,
+                            &api_from_currency,
+                            &api_to_currency,
+                        )
+                        .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2693,6 +2743,43 @@ fn wire__crate__api__raptor__get_qr_bytes_impl(
                     Ok(output_ok)
                 })(),
             )
+        },
+    )
+}
+fn wire__crate__api__network__get_supported_vs_currencies_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_supported_vs_currencies",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_api = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::network::get_supported_vs_currencies(&api_api).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
         },
     )
 }
@@ -5327,6 +5414,49 @@ fn wire__crate__api__account__update_account_impl(
         },
     )
 }
+fn wire__crate__api__transaction__update_historical_prices_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "update_historical_prices",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_currency = <String>::sse_decode(&mut deserializer);
+            let api_exchange_rate = <f64>::sse_decode(&mut deserializer);
+            let api_c = <crate::api::coin::Coin>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::transaction::update_historical_prices(
+                            api_currency,
+                            api_exchange_rate,
+                            &api_c,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 
 // Section: related_funcs
 
@@ -5698,6 +5828,22 @@ impl SseDecode for crate::api::frost::DKGStatus {
                 unimplemented!("");
             }
         }
+    }
+}
+
+impl SseDecode for crate::api::network::ExchangeRate {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_fromPrice = <f64>::sse_decode(deserializer);
+        let mut var_toPrice = <f64>::sse_decode(deserializer);
+        let mut var_fromCurrency = <String>::sse_decode(deserializer);
+        let mut var_toCurrency = <String>::sse_decode(deserializer);
+        return crate::api::network::ExchangeRate {
+            from_price: var_fromPrice,
+            to_price: var_toPrice,
+            from_currency: var_fromCurrency,
+            to_currency: var_toCurrency,
+        };
     }
 }
 
@@ -7053,96 +7199,109 @@ fn pde_ffi_dispatcher_primary_impl(
         57 => wire__crate__api__network__get_current_height_impl(port, ptr, rust_vec_len, data_len),
         58 => wire__crate__api__sync__get_db_height_impl(port, ptr, rust_vec_len, data_len),
         59 => wire__crate__api__frost__get_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__account__get_exported_data_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__mempool__get_mempool_tx_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__network__get_network_name_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__db__get_prop_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__coin__get_tor_client_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__account__get_tx_details_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__frost__has_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__frost__has_dkg_params_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__account__has_transparent_pub_key_impl(
+        60 => wire__crate__api__network__get_exchange_rate_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__account__get_exported_data_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__mempool__get_mempool_tx_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__network__get_network_name_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__db__get_prop_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__network__get_supported_vs_currencies_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        71 => wire__crate__api__account__import_account_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__init__init_app_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__crate__api__raptor__init_app_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__coin__init_datadir_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__network__init_datadir_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__frost__init_dkg_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__frost__init_sign_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__vault__init_vault_impl(port, ptr, rust_vec_len, data_len),
-        79 => {
+        68 => wire__crate__api__coin__get_tor_client_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__account__get_tx_details_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__frost__has_dkg_addresses_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__frost__has_dkg_params_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__account__has_transparent_pub_key_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        73 => wire__crate__api__account__import_account_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__init__init_app_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__raptor__init_app_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__api__coin__init_datadir_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__network__init_datadir_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__frost__init_dkg_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__frost__init_sign_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__vault__init_vault_impl(port, ptr, rust_vec_len, data_len),
+        81 => {
             wire__crate__api__frost__is_signing_in_progress_impl(port, ptr, rust_vec_len, data_len)
         }
-        86 => wire__crate__api__issuance__issue_asset_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__account__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__account__list_categories_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__db__list_db_names_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__account__list_folders_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__account__list_memos_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__account__list_notes_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__account__list_tx_history_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__zsa__list_zsa_holdings_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__account__lock_note_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__account__lock_recent_notes_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__account__max_spendable_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__account__new_account_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__pay__pack_transaction_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__pay__prepare_impl(port, ptr, rust_vec_len, data_len),
-        102 => wire__crate__api__account__print_keys_impl(port, ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__db__put_prop_impl(port, ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__network__query_lwd_list_impl(port, ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__account__receivers_default_impl(port, ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__account__remove_account_impl(port, ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__account__rename_category_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__account__rename_folder_impl(port, ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__account__reorder_account_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__frost__reset_sign_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__account__reset_sync_impl(port, ptr, rust_vec_len, data_len),
-        113 => wire__crate__api__sync__rewind_sync_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__pay__send_impl(port, ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__zsa__set_asset_name_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__frost__set_dkg_address_impl(port, ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__frost__set_dkg_params_impl(port, ptr, rust_vec_len, data_len),
-        119 => {
+        88 => wire__crate__api__issuance__issue_asset_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__account__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__account__list_categories_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__db__list_db_names_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__account__list_folders_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__account__list_memos_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__account__list_notes_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__account__list_tx_history_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__zsa__list_zsa_holdings_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__account__lock_note_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__account__lock_recent_notes_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__account__max_spendable_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__account__new_account_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__pay__pack_transaction_impl(port, ptr, rust_vec_len, data_len),
+        103 => wire__crate__api__pay__prepare_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__account__print_keys_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__db__put_prop_impl(port, ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__network__query_lwd_list_impl(port, ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__account__receivers_default_impl(port, ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__account__remove_account_impl(port, ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__account__rename_category_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__account__rename_folder_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__account__reorder_account_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__frost__reset_sign_impl(port, ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__account__reset_sync_impl(port, ptr, rust_vec_len, data_len),
+        115 => wire__crate__api__sync__rewind_sync_impl(port, ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__pay__send_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__zsa__set_asset_name_impl(port, ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__frost__set_dkg_address_impl(port, ptr, rust_vec_len, data_len),
+        119 => wire__crate__api__frost__set_dkg_params_impl(port, ptr, rust_vec_len, data_len),
+        121 => {
             wire__crate__api__transaction__set_tx_category_impl(port, ptr, rust_vec_len, data_len)
         }
-        120 => wire__crate__api__transaction__set_tx_price_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__api__account__show_ledger_sapling_address_impl(
+        122 => wire__crate__api__transaction__set_tx_price_impl(port, ptr, rust_vec_len, data_len),
+        123 => wire__crate__api__account__show_ledger_sapling_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        122 => wire__crate__api__account__show_ledger_transparent_address_impl(
+        124 => wire__crate__api__account__show_ledger_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        123 => wire__crate__api__account__sign_ledger_transaction_impl(
+        125 => wire__crate__api__account__sign_ledger_transaction_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        124 => wire__crate__api__pay__sign_transaction_impl(port, ptr, rust_vec_len, data_len),
-        125 => wire__crate__api__pay__store_pending_tx_impl(port, ptr, rust_vec_len, data_len),
-        126 => wire__crate__api__sync__synchronize_impl(port, ptr, rust_vec_len, data_len),
-        128 => {
+        126 => wire__crate__api__pay__sign_transaction_impl(port, ptr, rust_vec_len, data_len),
+        127 => wire__crate__api__pay__store_pending_tx_impl(port, ptr, rust_vec_len, data_len),
+        128 => wire__crate__api__sync__synchronize_impl(port, ptr, rust_vec_len, data_len),
+        130 => {
             wire__crate__api__account__tx_account_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        129 => wire__crate__api__account__tx_memo_default_impl(port, ptr, rust_vec_len, data_len),
-        130 => wire__crate__api__account__tx_note_default_impl(port, ptr, rust_vec_len, data_len),
-        131 => wire__crate__api__account__tx_output_default_impl(port, ptr, rust_vec_len, data_len),
-        132 => wire__crate__api__account__tx_spend_default_impl(port, ptr, rust_vec_len, data_len),
-        134 => wire__crate__api__account__unlock_all_notes_impl(port, ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__pay__unpack_transaction_impl(port, ptr, rust_vec_len, data_len),
-        136 => wire__crate__api__account__update_account_impl(port, ptr, rust_vec_len, data_len),
+        131 => wire__crate__api__account__tx_memo_default_impl(port, ptr, rust_vec_len, data_len),
+        132 => wire__crate__api__account__tx_note_default_impl(port, ptr, rust_vec_len, data_len),
+        133 => wire__crate__api__account__tx_output_default_impl(port, ptr, rust_vec_len, data_len),
+        134 => wire__crate__api__account__tx_spend_default_impl(port, ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__account__unlock_all_notes_impl(port, ptr, rust_vec_len, data_len),
+        137 => wire__crate__api__pay__unpack_transaction_impl(port, ptr, rust_vec_len, data_len),
+        138 => wire__crate__api__account__update_account_impl(port, ptr, rust_vec_len, data_len),
+        139 => wire__crate__api__transaction__update_historical_prices_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
         _ => unreachable!(),
     }
 }
@@ -7160,19 +7319,19 @@ fn pde_ffi_dispatcher_sync_impl(
         24 => wire__crate__api__coin__coin_set_lwd_impl(ptr, rust_vec_len, data_len),
         25 => wire__crate__api__coin__coin_set_proxy_impl(ptr, rust_vec_len, data_len),
         48 => wire__crate__api__key__generate_seed_impl(ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__key__get_key_pools_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__raptor__get_qr_bytes_impl(ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__key__is_tex_address_impl(ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__key__is_valid_address_impl(ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__key__is_valid_fvk_impl(ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__key__is_valid_key_impl(ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__key__is_valid_phrase_impl(ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__key__is_valid_transparent_address_impl(ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__pay__parse_payment_uri_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__account__receivers_from_ua_impl(ptr, rust_vec_len, data_len),
-        118 => wire__crate__api__init__set_log_stream_impl(ptr, rust_vec_len, data_len),
-        127 => wire__crate__api__pay__to_plan_impl(ptr, rust_vec_len, data_len),
-        133 => wire__crate__api__account__ua_from_ufvk_impl(ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__key__get_key_pools_impl(ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__raptor__get_qr_bytes_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__key__is_tex_address_impl(ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__key__is_valid_address_impl(ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__key__is_valid_fvk_impl(ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__key__is_valid_key_impl(ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__key__is_valid_phrase_impl(ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__key__is_valid_transparent_address_impl(ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__pay__parse_payment_uri_impl(ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__account__receivers_from_ua_impl(ptr, rust_vec_len, data_len),
+        120 => wire__crate__api__init__set_log_stream_impl(ptr, rust_vec_len, data_len),
+        129 => wire__crate__api__pay__to_plan_impl(ptr, rust_vec_len, data_len),
+        135 => wire__crate__api__account__ua_from_ufvk_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -7381,6 +7540,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::frost::DKGStatus>
     for crate::api::frost::DKGStatus
 {
     fn into_into_dart(self) -> crate::api::frost::DKGStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::network::ExchangeRate {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.from_price.into_into_dart().into_dart(),
+            self.to_price.into_into_dart().into_dart(),
+            self.from_currency.into_into_dart().into_dart(),
+            self.to_currency.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::network::ExchangeRate
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::network::ExchangeRate>
+    for crate::api::network::ExchangeRate
+{
+    fn into_into_dart(self) -> crate::api::network::ExchangeRate {
         self
     }
 }
@@ -8412,6 +8594,16 @@ impl SseEncode for crate::api::frost::DKGStatus {
                 unimplemented!("");
             }
         }
+    }
+}
+
+impl SseEncode for crate::api::network::ExchangeRate {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <f64>::sse_encode(self.from_price, serializer);
+        <f64>::sse_encode(self.to_price, serializer);
+        <String>::sse_encode(self.from_currency, serializer);
+        <String>::sse_encode(self.to_currency, serializer);
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the ability to select any fiat currency (from CoinGecko supported list) instead of hardcoded USD.

## Changes
### Backend (Rust)
- Parameterize get_coingecko_price with dynamic currency; parse JSON dynamically
- Add get_supported_vs_currencies - fetches alphabetical list from CoinGecko
- Add get_exchange_rate - fetches ZEC price in both old and new currency
- Add update_historical_prices - atomically converts all price columns and updates currency prop in a single DB transaction
- Add 15s timeout and User-Agent header to all CoinGecko reqwest calls

### Frontend (Flutter)
- Add currency field to AppSettings (stored in DB, defaults to usd)
- ExchangeRateButton widget - outlined button with auto-scaling rate display and tap-to-refresh
- CurrencyPage - alphabetical list with selection highlight; on back: confirmation dialog with pre-filled exchange rate, calls update_historical_prices on confirm, stays on page on cancel
- Currency row in Settings page (full-row tappable)
- Replace all hardcoded USD and dollar sign with dynamic formatFiat throughout the app