### PR TITLE
feat: make Account Page the home page, Account Manager from overflow …

### DIFF
--- a/lib/pages/account.dart
+++ b/lib/pages/account.dart
@@ -132,189 +132,204 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
     final pinlock = ref.watch(lifecycleProvider);
     if (pinlock.value ?? false) return PinLock();
 
-    final fullDataAV = ref.watch(fullAccountPageDataProvider);
+    final selectedAccountAV = ref.watch(selectedAccountProvider);
+    return selectedAccountAV.when(
+      loading: () => blank(context),
+      error: (error, stack) => showError(error),
+      data: (selectedAccount) {
+        if (selectedAccount == null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (GoRouter.of(context).state.matchedLocation == '/accounts') return;
+            GoRouter.of(context).go("/accounts");
+          });
+        }
 
-    Future(tutorial);
+        final fullDataAV = ref.watch(fullAccountPageDataProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(fullDataAV.value?.currentAccount?.account.name ?? "Loading"),
-        actions: [
-          Showcase(
-            key: sync1ID,
-            description: "Synchronize only this account",
-            child: IconButton(
-              tooltip: "Sync this account",
-              onPressed: fullDataAV.value?.currentAccount != null ? () => onSync(fullDataAV.value!.currentAccount!) : null,
-              icon: Icon(Icons.sync),
+        Future(tutorial);
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(fullDataAV.value?.currentAccount?.account.name ?? "Loading"),
+            actions: [
+              Showcase(
+                key: sync1ID,
+                description: "Synchronize only this account",
+                child: IconButton(
+                  tooltip: "Sync this account",
+                  onPressed: fullDataAV.value?.currentAccount != null ? () => onSync(fullDataAV.value!.currentAccount!) : null,
+                  icon: Icon(Icons.sync),
+                ),
+              ),
+              Showcase(
+                key: receiveID,
+                description: "Show the account receiving addresses",
+                child: IconButton(tooltip: "Receive Funds", onPressed: onReceive, icon: Icon(Icons.download)),
+              ),
+              Showcase(
+                key: sendID,
+                description: "Send funds to one or many addresses",
+                child: IconButton(tooltip: "Send Funds", onPressed: onSend, icon: Icon(Icons.send)),
+              ),
+              PopupMenuButton<String>(
+                onSelected: (String result) async {
+                  switch (result) {
+                    case "account_manager":
+                      GoRouter.of(context).push("/accounts");
+                    case "backup":
+                      final account = fullDataAV.value?.currentAccount?.account;
+                      if (account != null) {
+                        GoRouter.of(context).push("/viewing_keys", extra: account.id);
+                      }
+                    case "edit_account":
+                      final account = fullDataAV.value?.currentAccount?.account;
+                      if (account != null) {
+                        GoRouter.of(context).push("/account/edit", extra: [account]);
+                      }
+                    case "market_price":
+                      GoRouter.of(context).push("/market");
+                    case "update_fx":
+                      onUpdateAllTxPrices();
+                    case "charts":
+                      GoRouter.of(context).push("/chart");
+                    case "settings":
+                      GoRouter.of(context).push("/settings");
+                    default:
+                      onExport(int.parse(result));
+                  }
+                },
+                itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+                  const PopupMenuItem<String>(
+                    value: "account_manager",
+                    child: Text("Account Manager"),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: "settings",
+                    child: Text("Settings"),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: "edit_account",
+                    child: Text("Edit Account"),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: "backup",
+                    child: Text("Backup"),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: "market_price",
+                    child: Text("Market Price"),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: "update_fx",
+                    child: Text("Fetch Tx Prices"),
+                  ),
+                  PopupMenuItem<String>(
+                    value: tabIndex(context).toString(),
+                    child: Text("Export ${tabNames[tabIndex(context)]}"),
+                  ),
+                  if (!Platform.isLinux)
+                    const PopupMenuItem<String>(
+                      value: "charts",
+                      child: Text("Charts"),
+                    ),
+                ],
+              ),
+            ],
+            bottom: TabBar(
+              controller: tabController,
+              tabs: tabNames.map((n) => Tab(text: n)).toList(),
             ),
           ),
-          Showcase(
-            key: receiveID,
-            description: "Show the account receiving addresses",
-            child: IconButton(tooltip: "Receive Funds", onPressed: onReceive, icon: Icon(Icons.download)),
-          ),
-          Showcase(
-            key: sendID,
-            description: "Send funds to one or many addresses",
-            child: IconButton(tooltip: "Send Funds", onPressed: onSend, icon: Icon(Icons.send)),
-          ),
-          PopupMenuButton<String>(
-            onSelected: (String result) async {
-              switch (result) {
-                case "backup":
-                  final account = fullDataAV.value?.currentAccount?.account;
-                  if (account != null) {
-                    GoRouter.of(context).push("/viewing_keys", extra: account.id);
-                  }
-                case "edit_account":
-                  final account = fullDataAV.value?.currentAccount?.account;
-                  if (account != null) {
-                    GoRouter.of(context).push("/account/edit", extra: [account]);
-                  }
-                case "market_price":
-                  GoRouter.of(context).push("/market");
-                case "update_fx":
-                  onUpdateAllTxPrices();
-                case "charts":
-                  GoRouter.of(context).push("/chart");
-                case "settings":
-                  GoRouter.of(context).push("/settings");
-                default:
-                  onExport(int.parse(result));
-              }
-            },
-            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-              const PopupMenuItem<String>(
-                value: "settings",
-                child: Text("Settings"),
-              ),
-              const PopupMenuItem<String>(
-                value: "edit_account",
-                child: Text("Edit Account"),
-              ),
-              const PopupMenuItem<String>(
-                value: "backup",
-                child: Text("Backup"),
-              ),
-              const PopupMenuItem<String>(
-                value: "market_price",
-                child: Text("Market Price"),
-              ),
-              const PopupMenuItem<String>(
-                value: "update_fx",
-                child: Text("Fetch Tx Prices"),
-              ),
-              PopupMenuItem<String>(
-                value: tabIndex(context).toString(),
-                child: Text("Export ${tabNames[tabIndex(context)]}"),
-              ),
-              if (!Platform.isLinux)
-                const PopupMenuItem<String>(
-                  value: "charts",
-                  child: Text("Charts"),
-                ),
-            ],
-          ),
-        ],
-        bottom: TabBar(
-          controller: tabController,
-          tabs: tabNames.map((n) => Tab(text: n)).toList(),
-        ),
-      ),
-      body: fullDataAV.when(
-        skipLoadingOnReload: true,
-        skipLoadingOnRefresh: true,
-        loading: () => blank(context),
-        error: (error, stack) => showError(error),
-        data: (fullData) {
-          final account = fullData.currentAccount;
-          if (account == null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) => GoRouter.of(context).go("/"));
-            return const SizedBox.shrink();
-          }
+          body: fullDataAV.when(
+            skipLoadingOnReload: true,
+            skipLoadingOnRefresh: true,
+            loading: () => blank(context),
+            error: (error, stack) => showError(error),
+            data: (fullData) {
+              final account = fullData.currentAccount!;
 
-          final b = account.balance.field0;
-          final settings = ref.read(appSettingsProvider).requireValue;
-          final currency = settings.currency;
-          final fiat = fullData.price?.let((p) {
-            final f = (b[0] + b[1] + b[2]).toDouble() * p / zatsPerZec.toDouble();
-            return formatFiat(f, currency);
-          });
+              final b = account.balance.field0;
+              final settings = ref.read(appSettingsProvider).requireValue;
+              final currency = settings.currency;
+              final fiat = fullData.price?.let((p) {
+                final f = (b[0] + b[1] + b[2]).toDouble() * p / zatsPerZec.toDouble();
+                return formatFiat(f, currency);
+              });
 
-          final t = Theme.of(context);
-          final tt = t.textTheme;
+              final t = Theme.of(context);
+              final tt = t.textTheme;
 
-          final unconfirmedAmount = fullData.mempool.unconfirmedFunds[account.account.id];
+              final unconfirmedAmount = fullData.mempool.unconfirmedFunds[account.account.id];
 
-          return Builder(
-            builder: (context) {
-              final ss = fullData.syncState;
-              if (ss == null) return const SizedBox.shrink();
+              return Builder(
+                builder: (context) {
+                  final ss = fullData.syncState;
+                  if (ss == null) return const SizedBox.shrink();
 
-              final syncing = ss.start != ss.end;
-              return Padding(
-                  padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                  child: TabBarView(
-                    controller: tabController,
-                    children: [
-                      CustomScrollView(
-                        slivers: [
-                          PinnedHeaderSliver(
-                            child: Container(
-                              color: Theme.of(context).colorScheme.surface,
-                              child: Column(
-                                children: [
-                                  if (syncing) ...[
-                                    HeroProgressWidget(account.account),
-                                    Gap(8),
-                                  ],
-                                  DisplayPanel(
-                                      child: Column(children: [
-                                    Showcase(
-                                      key: balID,
-                                      description: "Balance across all pools",
-                                      child: Column(children: [
-                                        zatToText(
-                                          b[0] + b[1] + b[2],
-                                          selectable: true,
-                                          style: tt.displaySmall!,
+                  final syncing = ss.start != ss.end;
+                  return Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                      child: TabBarView(
+                        controller: tabController,
+                        children: [
+                          CustomScrollView(
+                            slivers: [
+                              PinnedHeaderSliver(
+                                child: Container(
+                                  color: Theme.of(context).colorScheme.surface,
+                                  child: Column(
+                                    children: [
+                                      if (syncing) ...[
+                                        HeroProgressWidget(account.account),
+                                        Gap(8),
+                                      ],
+                                      DisplayPanel(
+                                          child: Column(children: [
+                                        Showcase(
+                                          key: balID,
+                                          description: "Balance across all pools",
+                                          child: Column(children: [
+                                            zatToText(
+                                              b[0] + b[1] + b[2],
+                                              selectable: true,
+                                              style: tt.displaySmall!,
+                                            ),
+                                          ]),
                                         ),
                                         if (fiat != null) Text(fiat),
                                         const Gap(4),
                                         const ExchangeRateButton(),
+                                        Gap(8),
+                                        BalanceWidget(account.balance, showcase: true),
                                       ]),
                                     ),
                                     Gap(8),
-                                    BalanceWidget(account.balance, showcase: true),
+                                    if (unconfirmedAmount != null) ...[
+                                      zatToText(
+                                        BigInt.from(unconfirmedAmount),
+                                        prefix: "Unconfirmed: ",
+                                        colored: true,
+                                        selectable: true,
+                                        style: tt.bodyLarge,
+                                      ),
+                                      Gap(8),
+                                    ],
                                   ])),
-                                  Gap(8),
-                                  if (unconfirmedAmount != null) ...[
-                                    zatToText(
-                                      BigInt.from(unconfirmedAmount),
-                                      prefix: "Unconfirmed: ",
-                                      colored: true,
-                                      selectable: true,
-                                      style: tt.bodyLarge,
-                                    ),
-                                    Gap(8),
-                                  ],
-                                ],
                               ),
-                            ),
+                              ...showTxHistory(context, account.transactions),
+                            ],
                           ),
-                          ...showTxHistory(context, account.transactions),
+                          showMemos(context, account.memos),
+                          showNotes(ref, account.notes),
+                          _showZsaHoldings(context, account.zsas),
                         ],
-                      ),
-                      showMemos(context, account.memos),
-                      showNotes(ref, account.notes),
-                      _showZsaHoldings(context, account.zsas),
-                    ],
-                  ));
+                      ));
+                },
+              );
             },
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 
@@ -373,9 +388,7 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
             itemBuilder: (context, index) {
               final h = zsas[index];
 
-              final displayName = h.assetName.isNotEmpty
-                  ? h.assetName
-                  : hex.encode(h.assetDescHash.sublist(0, 4));
+              final displayName = h.assetName.isNotEmpty ? h.assetName : hex.encode(h.assetDescHash.sublist(0, 4));
 
               final isEditing = _editingIndex == index;
 
@@ -408,9 +421,7 @@ class AccountViewPageState extends ConsumerState<AccountViewPage> with SingleTic
                                 isDense: true,
                                 contentPadding: const EdgeInsets.symmetric(vertical: 4),
                                 border: const OutlineInputBorder(),
-                                hintText: h.assetName.isEmpty
-                                    ? hex.encode(h.assetDescHash.sublist(0, 4))
-                                    : null,
+                                hintText: h.assetName.isEmpty ? hex.encode(h.assetDescHash.sublist(0, 4)) : null,
                               ),
                               style: tt.titleMedium,
                             )

--- a/lib/pages/accounts.dart
+++ b/lib/pages/accounts.dart
@@ -270,7 +270,11 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
     // Wait for getCurrentAccountProvider (what the page watches) to complete
     await ref.read(getCurrentAccountProvider.future);
     if (!context.mounted) return;
-    await GoRouter.of(context).push('/account', extra: account);
+    if (GoRouter.of(context).canPop()) {
+      GoRouter.of(context).pop();
+    } else {
+      GoRouter.of(context).go('/');
+    }
   }
 
   void onReorder(int oldIndex, int newIndex) async {

--- a/lib/pages/splash.dart
+++ b/lib/pages/splash.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zkool/main.dart';
+import 'package:zkool/src/rust/api/db.dart';
 import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
 import 'package:zkool/widgets/error_display.dart';
@@ -33,11 +34,12 @@ class SplashPageState extends ConsumerState<SplashPage> {
         if (!openDatabaseSuccess!)
           GoRouter.of(context).go('/database_manager');
         else {
-          final selectedAccount = await ref.read(selectedAccountProvider.future);
-          if (selectedAccount != null) {
-            GoRouter.of(context).go("/account", extra: selectedAccount);
-          } else
+          final account = await ref.read(selectedAccountProvider.future);
+          if (account != null) {
             GoRouter.of(context).go("/");
+          } else {
+            GoRouter.of(context).go("/accounts");
+          }
         }
       });
     }
@@ -80,6 +82,11 @@ class SplashPageState extends ConsumerState<SplashPage> {
     final hasDb = ref.read(hasDbProvider.notifier);
     hasDb.setHasDb();
     ref.invalidate(appSettingsProvider);
+    // Restore persisted account ID from the Rust DB
+    final savedIdStr = await getProp(key: "selected_account", c: c);
+    final savedId = int.tryParse(savedIdStr ?? "") ?? 0;
+    ref.read(selectedAccountIdProvider.notifier).set(savedId);
+    ref.invalidate(selectedAccountProvider);
     final account = await ref.read(selectedAccountProvider.future);
     if (account != null) c = await c.setAccount(account: account.id);
 
@@ -88,7 +95,7 @@ class SplashPageState extends ConsumerState<SplashPage> {
       // initialize the Vault via provider
       await ref.read(vaultProvider.future);
     }
-    logger.i("LWD ${settings.lwd}");
+    logger.i("LWD ${settings.lwd}, account ${account?.id}");
     c = c.setLwd(
       serverType: settings.isLightNode ? 0 : 1,
       url: settings.lwd,

--- a/lib/pages/tx.dart
+++ b/lib/pages/tx.dart
@@ -234,7 +234,7 @@ class TxPageState extends ConsumerState<TxPage> {
   }
 
   void onCancel() {
-    GoRouter.of(context).go("/account");
+    GoRouter.of(context).go("/");
   }
 }
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -44,13 +44,11 @@ GoRouter router(bool disclaimerAccepted, bool recoveryMode) => GoRouter(
       routes: [
         GoRoute(
           path: '/',
+          builder: (context, state) => AccountViewPage(),
+        ),
+        GoRoute(
+          path: '/accounts',
           builder: (context, state) => AccountListPage(),
-          routes: [
-            GoRoute(
-              path: 'account',
-              builder: (context, state) => AccountViewPage(),
-            ),
-          ],
         ),
         GoRoute(
           path: '/account/edit',

--- a/lib/store.dart
+++ b/lib/store.dart
@@ -38,13 +38,14 @@ class HasDb extends _$HasDb {
   }
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 class SelectedAccountId extends _$SelectedAccountId {
   @override
   int build() => 0;
 
-  void set(int account) {
+  Future<void> set(int account) async {
     state = account;
+    await putProp(key: "selected_account", value: account.toString(), c: coinContext.coin);
   }
 }
 
@@ -229,7 +230,7 @@ Future<Account?> selectedAccount(Ref ref) async {
   final accountId = ref.watch(selectedAccountIdProvider);
   if (accountId == 0) return null;
   final accounts = await ref.watch(getAccountsProvider.future);
-  final acc = accounts.firstWhere((a) => a.id == accountId);
+  final acc = accounts.firstWhereOrNull((a) => a.id == accountId);
   return acc;
 }
 
@@ -956,8 +957,10 @@ sealed class AccountPageData with _$AccountPageData {
 @riverpod
 Future<AccountPageData> accountPageData(Ref ref) async {
   final basicData = await ref.watch(basicAccountDataProvider.future);
-  final accountId = basicData.currentAccount?.account.id ?? 0;
-  final syncState = await ref.watch(syncStateAccountProvider(accountId).future);
+  final accountId = basicData.currentAccount?.account.id;
+  final syncState = accountId != null
+      ? await ref.watch(syncStateAccountProvider(accountId).future)
+      : null;
 
   return AccountPageData(
     allAccounts: basicData.allAccounts,

--- a/lib/store.g.dart
+++ b/lib/store.g.dart
@@ -66,7 +66,7 @@ final class SelectedAccountIdProvider
           argument: null,
           retry: null,
           name: r'selectedAccountIdProvider',
-          isAutoDispose: true,
+          isAutoDispose: false,
           dependencies: null,
           $allTransitiveDependencies: null,
         );


### PR DESCRIPTION
…menu

Route restructuring:
- / now renders AccountViewPage (Account Page) instead of AccountListPage
- New /accounts route for AccountListPage (Account Manager)
- Removed nested /account sub-route

Navigation:
- Select account from AM: pop back if pushed, go('/') if root
- Tx cancel navigates to / instead of /account
- Splash restores selected_account from DB prop, navigates conditionally

Persistence:
- SelectedAccountId now keepAlive and persists to DB via putProp
- selectedAccountProvider uses firstWhereOrNull for deleted accounts

AccountViewPage:
- Redirect decision uses selectedAccountProvider directly (no async cascade)
- Account Manager added as first item in overflow menu
- Null-account redirect targets /accounts with guard against loops

Fixes:
- accountPageData handles null currentAccount without crashing syncState fetch