### PR TITLE
fix: fix server ordering

### DIFF
--- a/lib/pages/lwd_select.dart
+++ b/lib/pages/lwd_select.dart
@@ -16,9 +16,9 @@ class LWDSelectPage extends ConsumerStatefulWidget {
 }
 
 class _LWDSelectPageState extends ConsumerState<LWDSelectPage> {
-  int _sortColumnIndex = 0;
-  bool _sortAscending = true;
-  bool? _onlineFilter; // null = all, true = online, false = offline
+  int _sortColumnIndex = 3; // Uptime
+  bool _sortAscending = false; // descending
+  bool? _onlineFilter = true; // null = all, true = online, false = offline
 
   List<LWDInfo>? _servers;
   bool _loading = true;

--- a/rust/src/net/lwd.rs
+++ b/rust/src/net/lwd.rs
@@ -187,8 +187,8 @@ impl LwdServer for GRPCClient {
 }
 
 pub async fn query_lwd_list() -> Result<Vec<LWDInfo>> {
-    // Implement by querying https://hosh.zec.rocks/api/v0/zec.json
-     let rep = reqwest::get("https://hosh.zec.rocks/api/v0/zec.json")
+    // Implement by querying https://hosh.zec.rocks/api/v0/zec.json?chain=main
+     let rep = reqwest::get("https://hosh.zec.rocks/api/v0/zec.json?chain=main")
         .await?
         .error_for_status()?
         .json::<serde_json::Value>()


### PR DESCRIPTION
closes #1022

1. Online selected by default — _onlineFilter = true (was null/All).
2. Sort by Uptime descending — _sortColumnIndex = 3 (Uptime column) with _sortAscending = false.
3. URL with ?chain=main — updated the query in rust/src/net/lwd.rs:191.