### PR TITLE
GH attestations

### DIFF
--- a/.github/actions/zebra/action.yml
+++ b/.github/actions/zebra/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Cache zebra
       id: cache-zebra
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ./tools/bin
@@ -38,7 +38,7 @@ runs:
 
     - name: Save cache
       if: steps.cache-zebra.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ./tools/bin
         key: ${{ runner.os }}-zebra-lwd-5.0.0

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,28 +28,28 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: misc/alpine.dockerfile
           tags: ${{ env.REGISTRY_IMAGE }}
@@ -62,7 +62,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -75,24 +75,24 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: type=semver,pattern={{version}},match=v(\d+.\d+.\d+(-rc.\d+)?)$

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install RUST
         uses: dtolnay/rust-toolchain@stable
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build zkool_graphql
         run: |
           sudo apt-get update
@@ -30,7 +30,7 @@ jobs:
           RUSTFLAGS: '--cfg zcash_unstable="nu7"'
       - name: Create Release
         if: startsWith(github.ref_name, 'zkool-v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./target/release/zkool_graphql
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Install RUST
         uses: dtolnay/rust-toolchain@stable
       - name: Install PYTHON
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Flutter
         shell: bash
         run: |
@@ -102,7 +102,7 @@ jobs:
           echo "outdir=${{ steps.build_android.outputs.outdir || steps.build_linux.outputs.outdir || steps.build_mac.outputs.outdir || steps.build_windows.outputs.outdir }}" >> $GITHUB_OUTPUT
       - name: Upload build artifacts
         if: startsWith(github.ref_name, 'zkool-v')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.target }}-${{ matrix.arch }}
           path: ${{ steps.collect.outputs.outdir }}/*
@@ -118,7 +118,7 @@ jobs:
       attestations: write   # write attestation to GitHub
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compute version
         id: version
         shell: bash
@@ -128,7 +128,7 @@ jobs:
           BUILD=$(cat build_number.txt)
           echo "distname=${NAME}-${SEMVER}+${BUILD}" >> $GITHUB_OUTPUT
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: dist-*
@@ -141,14 +141,14 @@ jobs:
           cat SHA256SUMS
       - name: Attest build provenance
         id: attest
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-checksums: dist/SHA256SUMS
       - name: Stage attestation bundle
         shell: bash
         run: cp "${{ steps.attest.outputs.bundle-path }}" "dist/${{ steps.version.outputs.distname }}.intoto.jsonl"
       - name: Upload assets to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,11 +100,93 @@ jobs:
         run: |
           df -h
           echo "outdir=${{ steps.build_android.outputs.outdir || steps.build_linux.outputs.outdir || steps.build_mac.outputs.outdir || steps.build_windows.outputs.outdir }}" >> $GITHUB_OUTPUT
-      - name: Create Release
+      - name: Upload build artifacts
         if: startsWith(github.ref_name, 'zkool-v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}-${{ matrix.arch }}
+          path: ${{ steps.collect.outputs.outdir }}/*
+          if-no-files-found: error
+
+  release:
+    needs: build
+    if: startsWith(github.ref_name, 'zkool-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # edit release / upload assets
+      id-token: write       # sigstore OIDC for attestation
+      attestations: write   # write attestation to GitHub
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          NAME=$(sed -n 's/^name: *\([^ ]*\).*/\1/p' pubspec.yaml)
+          SEMVER=$(sed -n 's/^version: *\([^ ]*\).*/\1/p' pubspec.yaml)
+          BUILD=$(cat build_number.txt)
+          echo "distname=${NAME}-${SEMVER}+${BUILD}" >> $GITHUB_OUTPUT
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          cd dist
+          find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS
+          cat SHA256SUMS
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-checksums: dist/SHA256SUMS
+      - name: Stage attestation bundle
+        shell: bash
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "dist/${{ steps.version.outputs.distname }}.intoto.jsonl"
+      - name: Upload assets to release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ steps.collect.outputs.outdir }}/*
+          files: dist/*
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Append attestation notes
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          DISTNAME: ${{ steps.version.outputs.distname }}
+        run: |
+          CHECKSUMS=$(cat dist/SHA256SUMS)
+          BODY=$(gh release view "$TAG" --repo "$REPO" --json body -q .body)
+          gh release edit "$TAG" --repo "$REPO" --notes "$(cat <<EOF
+          $BODY
+
+          ### Attestations
+
+          Each released binary carries a signed GitHub build-provenance
+          attestation. To verify a file you downloaded:
+
+          \`\`\`sh
+          # Verify against the attestations stored on GitHub (needs network):
+          gh attestation verify <file> --repo $REPO
+
+          # Or verify fully offline using the bundle attached to this release:
+          gh attestation verify <file> --bundle $DISTNAME.intoto.jsonl
+          \`\`\`
+
+          \`SHA256SUMS\` lists the digest of every artifact; check a downloaded
+          file against it to confirm integrity.
+
+          ### Checksums
+
+          \`\`\`
+          $CHECKSUMS
+          \`\`\`
+          EOF
+          )"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,9 @@ jobs:
       major: ${{ steps.release.outputs.major }}
       minor: ${{ steps.release.outputs.minor }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/wallet.yml
+++ b/.github/workflows/wallet.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install RUST
         uses: dtolnay/rust-toolchain@stable
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup regtest
         uses: hhanh00/zkool2/.github/actions/zebra@main
         with:


### PR DESCRIPTION
closes #1064

Also updates github actions to address warning `Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v4, actions/upload-artifact@v4.`