### PR TITLE
TTL-cache getCurrentHeight in async provider with offline check

### DIFF
--- a/lib/pages/account.dart
+++ b/lib/pages/account.dart
@@ -931,7 +931,7 @@ Widget showMemos(BuildContext context, List<Memo> memos, VoidCallback onMemoChan
 
 Widget showNotes(WidgetRef ref, List<TxNote> notes) {
   final t = Theme.of(navigatorKey.currentContext!);
-  final currentHeight = ref.read(currentHeightProvider);
+  final currentHeight = ref.read(currentHeightProvider).value;
   return ListView.builder(
     itemCount: notes.length + 1,
     itemBuilder: (context, index) {

--- a/lib/pages/accounts.dart
+++ b/lib/pages/accounts.dart
@@ -11,7 +11,6 @@ import 'package:zkool/main.dart';
 import 'package:zkool/pages/account.dart';
 import 'package:zkool/router.dart';
 import 'package:zkool/src/rust/api/account.dart';
-import 'package:zkool/src/rust/api/network.dart';
 import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
 import 'package:zkool/widgets/error_display.dart';
@@ -51,13 +50,10 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
   }
 
   void refreshHeight(bool fetchPrice) async {
-    final settings = ref.read(appSettingsProvider).requireValue;
-    if (settings.offline) return;
     try {
-      final height = await getCurrentHeight(c: coinContext.coin);
-      final currentHeight = ref.read(currentHeightProvider.notifier);
-      currentHeight.setHeight(height);
+      await ref.read(currentHeightProvider.notifier).fetch(force: true);
       if (fetchPrice) {
+        final settings = ref.read(appSettingsProvider).requireValue;
         final currentPrice = ref.read(priceProvider.notifier);
         await currentPrice.fetch(settings.coingecko, settings.currency);
       }
@@ -82,7 +78,7 @@ class AccountListPageState extends ConsumerState<AccountListPage> with RouteAwar
         final accountList =
             pageData.accounts.where((a) => !a.internal && (includeHidden || !a.hidden) && a.folder.id == (pageData.selectedFolder?.id ?? 0)).toList();
 
-        final currentHeight = ref.watch(currentHeightProvider);
+        final currentHeight = ref.watch(currentHeightProvider).value;
         final h = currentHeight != null ? currentHeight.toString() : 'N/A';
 
         final visibleAccounts = pageData.accounts.where((a) => !a.internal).toList();

--- a/lib/pages/dkg.dart
+++ b/lib/pages/dkg.dart
@@ -12,7 +12,6 @@ import 'package:go_router/go_router.dart';
 import 'package:zkool/main.dart';
 import 'package:zkool/src/rust/api/account.dart';
 import 'package:zkool/src/rust/api/frost.dart';
-import 'package:zkool/src/rust/api/network.dart';
 import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
 import 'package:zkool/widgets/error_display.dart';
@@ -323,7 +322,6 @@ class DKGPage3State extends ConsumerState<DKGPage3> {
   String message = "";
   int index = 0;
   Timer? runTimer;
-  int? currentHeight;
   bool finished = false;
 
   @override
@@ -343,9 +341,7 @@ class DKGPage3State extends ConsumerState<DKGPage3> {
 
   Future<void> runDkg() async {
     try {
-      final h = await getCurrentHeight(c: c);
-      if (currentHeight != null && currentHeight == h) return;
-      currentHeight = h;
+      await ref.read(currentHeightProvider.notifier).fetch();
       final as = await ref.read(getAccountsProvider.future);
       final accounts = as.where((e) => e.enabled).toList();
       final synchronizer = ref.read(synchronizerProvider.notifier);

--- a/lib/pages/frost.dart
+++ b/lib/pages/frost.dart
@@ -12,7 +12,6 @@ import 'package:go_router/go_router.dart';
 import 'package:zkool/main.dart';
 import 'package:zkool/src/rust/api/account.dart';
 import 'package:zkool/src/rust/api/frost.dart';
-import 'package:zkool/src/rust/api/network.dart';
 import 'package:zkool/src/rust/api/pay.dart';
 import 'package:zkool/store.dart';
 import 'package:zkool/utils.dart';
@@ -221,13 +220,9 @@ class FrostPage2State extends ConsumerState<FrostPage2> {
     );
   }
 
-  int? currentHeight;
-
   void runFrost() async {
     try {
-      final h = await getCurrentHeight(c: c);
-      if (currentHeight != null && currentHeight == h) return;
-      currentHeight = h;
+      await ref.read(currentHeightProvider.notifier).fetch();
       final as = await ref.read(getAccountsProvider.future);
       final accounts = as.where((e) => e.enabled).toList();
       final synchronizer = ref.read(synchronizerProvider.notifier);

--- a/lib/pages/new_account.dart
+++ b/lib/pages/new_account.dart
@@ -325,7 +325,7 @@ class NewAccountPageState extends ConsumerState<NewAccountPage> {
 
   void onSave() async {
     if (formKey.currentState?.saveAndValidate() ?? false) {
-      final currentHeight = ref.read(currentHeightProvider);
+      final currentHeight = ref.read(currentHeightProvider).value;
 
       // Handle the save logic here
       final formData = formKey.currentState?.value;

--- a/lib/pages/tx.dart
+++ b/lib/pages/tx.dart
@@ -229,7 +229,7 @@ class TxPageState extends ConsumerState<TxPage> {
     setState(() => _sending = true);
     try {
       // Check if wallet is synced before sending
-      final currentHeight = ref.read(currentHeightProvider);
+      final currentHeight = ref.read(currentHeightProvider).value;
       final accountHeight = account!.height;
       if (currentHeight != null && accountHeight < currentHeight) {
         final syncChoice = await _showSyncWarning(currentHeight, accountHeight);

--- a/lib/pages/zsa.dart
+++ b/lib/pages/zsa.dart
@@ -326,7 +326,7 @@ class _IssueAssetPageState extends ConsumerState<IssueAssetPage> {
         idAccount: coinContext.coin.account,
         c: coinContext.coin,
       );
-      final height = ref.read(currentHeightProvider) ?? 1;
+      final height = ref.read(currentHeightProvider).value ?? 1;
       final txid = await broadcastTransaction(
         height: height,
         txBytes: txBytes,

--- a/lib/store.dart
+++ b/lib/store.dart
@@ -504,14 +504,38 @@ class LogNotifier extends _$LogNotifier {
 }
 
 @Riverpod(keepAlive: true)
-class CurrentHeightNotifier extends _$CurrentHeightNotifier {
-  @override
-  int? build() => null;
+class CurrentHeight extends _$CurrentHeight {
+  int? _cachedHeight;
+  DateTime? _lastFetch;
+  static const _ttl = Duration(seconds: 15);
 
-  bool setHeight(int height) {
-    if (state == height) return false;
-    state = height;
-    return true;
+  @override
+  Future<int?> build() async {
+    return await _doFetch();
+  }
+
+  /// Get current height, cached up to 15s. Respects offline mode.
+  /// Set [force] to true to bypass the TTL cache.
+  Future<int?> fetch({bool force = false}) async {
+    final settings = await ref.read(appSettingsProvider.future);
+    if (settings.offline) {
+      return _cachedHeight;
+    }
+    if (!force) {
+      final now = DateTime.now();
+      if (_cachedHeight != null && _lastFetch != null &&
+          now.difference(_lastFetch!) < _ttl) {
+        return _cachedHeight;
+      }
+    }
+    return await _doFetch();
+  }
+
+  Future<int?> _doFetch() async {
+    _cachedHeight = await getCurrentHeight(c: coinContext.coin);
+    _lastFetch = DateTime.now();
+    state = AsyncData(_cachedHeight);
+    return _cachedHeight;
   }
 }
 
@@ -773,10 +797,8 @@ class SynchronizerNotifier extends _$SynchronizerNotifier {
       return;
     }
     try {
-      final c = coinContext.coin;
-      final currentHeight = await getCurrentHeight(c: c);
-      final h = ref.read(currentHeightProvider.notifier);
-      if (h.setHeight(currentHeight)) {
+      final currentHeight = await ref.read(currentHeightProvider.notifier).fetch();
+      if (currentHeight != null) {
         await syncIfNeeded(currentHeight, now: now);
       }
     } on AnyhowException catch (e) {

--- a/lib/store.g.dart
+++ b/lib/store.g.dart
@@ -664,12 +664,12 @@ abstract class _$LogNotifier extends $Notifier<List<String>> {
   }
 }
 
-@ProviderFor(CurrentHeightNotifier)
-const currentHeightProvider = CurrentHeightNotifierProvider._();
+@ProviderFor(CurrentHeight)
+const currentHeightProvider = CurrentHeightProvider._();
 
-final class CurrentHeightNotifierProvider
-    extends $NotifierProvider<CurrentHeightNotifier, int?> {
-  const CurrentHeightNotifierProvider._()
+final class CurrentHeightProvider
+    extends $AsyncNotifierProvider<CurrentHeight, int?> {
+  const CurrentHeightProvider._()
       : super(
           from: null,
           argument: null,
@@ -681,33 +681,27 @@ final class CurrentHeightNotifierProvider
         );
 
   @override
-  String debugGetCreateSourceHash() => _$currentHeightNotifierHash();
+  String debugGetCreateSourceHash() => _$currentHeightHash();
 
   @$internal
   @override
-  CurrentHeightNotifier create() => CurrentHeightNotifier();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(int? value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<int?>(value),
-    );
-  }
+  CurrentHeight create() => CurrentHeight();
 }
 
-String _$currentHeightNotifierHash() =>
-    r'16daa9bce5d88e0c013ac53051b9c0479659ff6d';
+String _$currentHeightHash() => r'83f6fa7bfb3bee9f854fdc8c7ecc96c04075c8be';
 
-abstract class _$CurrentHeightNotifier extends $Notifier<int?> {
-  int? build();
+abstract class _$CurrentHeight extends $AsyncNotifier<int?> {
+  FutureOr<int?> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int?, int?>;
+    final ref = this.ref as $Ref<AsyncValue<int?>, int?>;
     final element = ref.element as $ClassProviderElement<
-        AnyNotifier<int?, int?>, int?, Object?, Object?>;
+        AnyNotifier<AsyncValue<int?>, int?>,
+        AsyncValue<int?>,
+        Object?,
+        Object?>;
     element.handleValue(ref, created);
   }
 }
@@ -795,7 +789,7 @@ final class SynchronizerNotifierProvider
 }
 
 String _$synchronizerNotifierHash() =>
-    r'558e7832444bfa102f87a85a6b00bccda2323e01';
+    r'58835d89675b8357fa32cc1dfcbf65be0b49d147';
 
 abstract class _$SynchronizerNotifier extends $Notifier<SyncState> {
   SyncState build();


### PR DESCRIPTION
- Replace sync CurrentHeightNotifier with async CurrentHeight AsyncNotifier
- 15s TTL cache, fetch(force: true) bypasses for user-initiated refresh
- Offline check inside provider via appSettingsProvider
- Remove setHeight, all callers use fetch()
- frost/dkg: remove direct getCurrentHeight calls and local currentHeight fields
- Remove unused network.dart imports