### PR TITLE
fix(graphql): download sapling params on startup

### DIFF
--- a/rust/src/graphql-cli.rs
+++ b/rust/src/graphql-cli.rs
@@ -97,6 +97,21 @@ async fn main() -> Result<()> {
     // convert key format: openssl pkcs8 -topk8 -nocrypt -in private.pem -out private_p8.pem
     // issue jwt: jwt encode --secret @private_p8.pem --alg ES256 --exp=<epoch secs> --sub=<account id> '{"write": true}'
 
+    // Initialise the data directory so Sapling params are stored in a known location.
+    let data_dir = std::path::Path::new(&db_path)
+        .parent()
+        .and_then(|p| if p.as_os_str().is_empty() { None } else { Some(p) })
+        .unwrap_or(std::path::Path::new("."));
+    rlz::api::coin::init_datadir(&data_dir.to_string_lossy()).await?;
+
+    // Download Sapling proving parameters if they are not already on disk.
+    let sapling_status = rlz::api::sapling::check_sapling_params();
+    if !sapling_status.downloaded {
+        tracing::info!("Sapling parameters not found, downloading …");
+        rlz::api::sapling::download_sapling_params().await?;
+        tracing::info!("Sapling parameters downloaded successfully");
+    }
+
     let server_type: u8 = if zebra { 1 } else { 0 };
     tracing::info!("db_path {db_path} lwd_url {lwd_url} port {port} zebra {zebra}");
     let coin = Coin::new()

--- a/rust/src/graphql-cli.rs
+++ b/rust/src/graphql-cli.rs
@@ -97,14 +97,8 @@ async fn main() -> Result<()> {
     // convert key format: openssl pkcs8 -topk8 -nocrypt -in private.pem -out private_p8.pem
     // issue jwt: jwt encode --secret @private_p8.pem --alg ES256 --exp=<epoch secs> --sub=<account id> '{"write": true}'
 
-    // Initialise the data directory so Sapling params are stored in a known location.
-    let data_dir = std::path::Path::new(&db_path)
-        .parent()
-        .and_then(|p| if p.as_os_str().is_empty() { None } else { Some(p) })
-        .unwrap_or(std::path::Path::new("."));
-    rlz::api::coin::init_datadir(&data_dir.to_string_lossy()).await?;
-
-    // Download Sapling proving parameters if they are not already on disk.
+    // Download Sapling proving parameters to the default location
+    // (typically $HOME/.zcash-params/) if they are not already on disk.
     let sapling_status = rlz::api::sapling::check_sapling_params();
     if !sapling_status.downloaded {
         tracing::info!("Sapling parameters not found, downloading …");


### PR DESCRIPTION
The GraphQL binary was not downloading Sapling proving parameters, causing failures when creating shielded transactions.

Now calls `check_sapling_params()` and `download_sapling_params()` at startup, storing params in the default librustzcash location. On macOS: `~/Library/Application Support/ZcashParams`.