### PR TITLE
fix: honour RUST_LOG in zkool_graphql

### DIFF
--- a/rust/src/graphql-cli.rs
+++ b/rust/src/graphql-cli.rs
@@ -60,8 +60,14 @@ async fn main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .unwrap();
+    // Without an EnvFilter the subscriber is pinned at INFO and RUST_LOG is
+    // silently ignored, so no debug! output from the sync path is ever visible.
     let subscriber = tracing_subscriber::fmt()
         .with_ansi(false)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
         .compact()
         .finish();
     let c = Config::parse();


### PR DESCRIPTION
The tracing subscriber in `zkool_graphql` is built without an `EnvFilter`, which pins it at INFO and silently discards `RUST_LOG`. None of the `debug!` instrumentation in the sync path can ever be observed, so diagnosing a sync problem is much harder than it needs to be — the instrumentation is already there, it just cannot be turned on.

Falls back to `info` when `RUST_LOG` is unset, so default behaviour is unchanged.

-------------
First of three independent fixes from one investigation into funds not appearing in a fully-synced wallet. The other two are sync correctness issues and are opened separately; I will link them here. They touch different files and can be reviewed and merged in any order.