### PR TITLE
fix: always scan the internal scope for shielded notes

### DIFF
--- a/rust/src/warp/sync/shielded.rs
+++ b/rust/src/warp/sync/shielded.rs
@@ -116,14 +116,16 @@ impl<P: ShieldedProtocol> Synchronizer<P> {
         tree_state: Edge,
     ) -> Result<Self> {
         let mut keys = vec![];
-        for (id, use_internal) in accounts.iter() {
+        for (id, _use_internal) in accounts.iter() {
             if let Some((ivk, nk)) = P::extract_ivk(&mut *connection, *id, 0).await? {
                 keys.push((*id, 0u8, ivk, nk));
             }
-            if *use_internal {
-                if let Some((ivk, nk)) = P::extract_ivk(&mut *connection, *id, 1).await? {
-                    keys.push((*id, 1u8, ivk, nk));
-                }
+            // Always trial-decrypt with the internal scope key. `use_internal`
+            // only decides where *new* change is sent (see pay/plan.rs); gating
+            // discovery on it makes notes already received on the internal
+            // scope permanently invisible and their value disappear.
+            if let Some((ivk, nk)) = P::extract_ivk(&mut *connection, *id, 1).await? {
+                keys.push((*id, 1u8, ivk, nk));
             }
         }
 


### PR DESCRIPTION
`Synchronizer::new` loads the scope-0 viewing key unconditionally, but the scope-1 (internal) key only when `accounts.use_internal` is set. A note received on the internal scope by an account with `use_internal = 0` is therefore never trial-decrypted, never reaches the `notes` table, and its value is absent from the balance.

The failure mode is severe. If every shielded note an account holds sits on the internal scope, **both shielded pool balances read as zero while the wallet reports itself fully synced to the tip**. Shielding transactions then appear to send funds out with nothing arriving, because only the transparent leg is recorded. Since `calculate_balance` is a pure function of the `notes` and `spends` tables, this is a scanning problem, not a display one.

`use_internal` is meant to select where *new* change is sent — `pay/plan.rs` derives `change_scope` from it. Gating note *discovery* on the same flag makes funds already received on the internal scope unreachable, and clearing the flag retroactively hides them. Discovery should always cover both scopes; only change placement should depend on the flag.

Verified against a real mainnet wallet exhibiting exactly this: a clean `resetAccount` plus full resync then reported the correct balance in every pool, where the released build reported near zero.

`cargo test -p rlz` shows no regressions. The only deterministic failure, `openalias::tests::test_parse_oa1_full`, fails identically on unmodified `main`; the two `plugin::rhai_api` tests are flaky under test parallelism on `main` as well (single-threaded runs are stable).

--------------
Second of three independent fixes — see #1190 for the first. Different files, mergeable in any order.