### PR TITLE
fix: add transparent gap-limit look-ahead during sync

### DIFF
--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -40,6 +40,9 @@ use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 pub const DEFAULT_ACTIONS_PER_SYNC: u32 = 10000u32;
 pub const DEFAULT_TRANSPARENT_LIMIT: u32 = 100u32;
+/// Unused look-ahead addresses kept beyond the highest address that has
+/// received funds (BIP44 gap limit, as used by other Zcash wallets).
+pub const TRANSPARENT_GAP_LIMIT: u32 = 20u32;
 
 pub use zcash_trees::types::SyncError;
 pub use zcash_trees::types::{BlockHeader, Issuance, Note, Transaction, WarpSyncMessage, UTXO};
@@ -308,6 +311,63 @@ pub async fn synchronize_impl<S: Sink<SyncProgress> + Send + 'static>(
     Ok(current_height)
 }
 
+/// Materialize look-ahead transparent addresses so `transparent_sync` actually
+/// queries them. Without this only addresses the user happened to generate are
+/// ever scanned, so funds received on the next unused address stay invisible
+/// no matter how far the chain is synced.
+async fn extend_transparent_gap(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    account: u32,
+) -> Result<()> {
+    let tk = select_account_transparent(&mut *connection, account, 0).await?;
+    let Some(xvk) = tk.xvk.as_ref() else {
+        return Ok(()); // imported single address / no xpub: nothing to derive
+    };
+    for scope in 0..2u32 {
+        let (last_used,): (Option<u32>,) = sqlx::query_as(
+            "SELECT MAX(ta.dindex) FROM transparent_address_accounts ta
+            JOIN notes n ON n.taddress = ta.id_taddress
+            WHERE ta.account = ?1 AND ta.scope = ?2",
+        )
+        .bind(account)
+        .bind(scope)
+        .fetch_one(&mut *connection)
+        .await?;
+        let (last_stored,): (Option<u32>,) = sqlx::query_as(
+            "SELECT MAX(dindex) FROM transparent_address_accounts
+            WHERE account = ?1 AND scope = ?2",
+        )
+        .bind(account)
+        .bind(scope)
+        .fetch_one(&mut *connection)
+        .await?;
+
+        let target = last_used.map_or(TRANSPARENT_GAP_LIMIT - 1, |u| u + TRANSPARENT_GAP_LIMIT);
+        let start = last_stored.map_or(0, |h| h + 1);
+        for dindex in start..=target {
+            let (pk, taddr) = derive_transparent_address(xvk, scope, dindex, false)?;
+            let sk = tk
+                .xsk
+                .as_ref()
+                .map(|xsk| derive_transparent_sk(xsk, scope, dindex))
+                .transpose()?;
+            store_account_transparent_addr(
+                &mut *connection,
+                account,
+                scope,
+                dindex,
+                sk,
+                &pk,
+                &taddr.encode(network),
+                false,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn transparent_sync(
     network: &Network,
@@ -324,6 +384,12 @@ pub(crate) async fn transparent_sync(
         "transparent_sync: scanning accounts {:?} from height {} to {} with limit {}",
         accounts, start_height, end_height, limit
     );
+    // Keep a gap-limit window of look-ahead addresses before building the scan
+    // list below, otherwise addresses that were never generated locally are
+    // never queried and their funds are missed.
+    for account in accounts {
+        extend_transparent_gap(network, &mut *connection, *account).await?;
+    }
     for account in accounts {
         // scan the most recent receive and change addresses, bounded by `limit`
         let mut rows = sqlx::query("


### PR DESCRIPTION
`transparent_sync` builds its scan list solely from rows already present in `transparent_address_accounts`, and that table only gains rows when an address is explicitly generated (receive-address advance, change generation, or the manual sweep). Funds sent to an address derived from the account's own key but never materialised locally are therefore never queried, and stay invisible no matter how far the chain is synced. A full reset and resync reproduces the identical incomplete state, because the scan list is rebuilt from the same table.

This is easy to hit whenever a seed is restored in more than one wallet: the other wallet hands out the next BIP44 index, and this one has no row for that index and never asks the server about it.

`extend_transparent_gap` keeps `TRANSPARENT_GAP_LIMIT` (20) unused addresses beyond the highest address that has received funds — the BIP44 convention other wallets follow. Gap-limit derivation already exists in `transparent_sweep`, but only as a manual recovery action; this reuses the same `derive_transparent_address` / `derive_transparent_sk` / `store_account_transparent_addr` helpers so look-ahead addresses carry spending keys, and no-ops for accounts with no xpub (bip38-imported single addresses).

Verified against a real mainnet wallet: after a clean `resetAccount` plus full resync the previously invisible funds are found and the transaction resolves at its true height with the correct value. No test regressions (same pre-existing `openalias` failure and `rhai_api` parallelism flakiness as on `main`).

### Upgrade note

`transparent_sync` queries each address only over the current sync range, so on an already-synced wallet a newly registered look-ahead address is scanned for subsequent blocks only. **Existing wallets need one rescan after upgrading** to recover funds already received on an unregistered address. I am happy to follow up with a change that scans newly materialised addresses from the account birth height — as `transparent_sweep` already does — so recovery is automatic; I left it out here to keep the diff focused.

### Related, not fixed here

`generate_next_dindex` advances the diversifier index via `svk.find_address()`, i.e. it only accepts *Sapling-valid* indices, then registers the transparent address at that same index. Roughly half of all BIP44 transparent indices are therefore unreachable through the Receive screen — on the wallet I looked at, pressing "new address" walked 8 → 14 → 19 → 20 → 21 → 24 → …, skipping the index that actually held funds. The gap limit compensates in practice, but coupling transparent derivation to Sapling diversifier validity seems worth addressing on its own. Happy to open a separate issue.

-------------
Third of three independent fixes — see #1190 and #1191. Different files, mergeable in any order.