### PR TITLE
fix(nym): make large syncs over the mixnet reliable

### DIFF
--- a/rust/src/api/coin.rs
+++ b/rust/src/api/coin.rs
@@ -181,6 +181,12 @@ impl Coin {
         Ok(Coin { proxy, ..self })
     }
 
+    /// True when traffic to the server goes through the Nym mixnet, either
+    /// via a mixnet-native nym:// endpoint or the Nym transport.
+    pub(crate) fn is_mixnet(&self) -> bool {
+        crate::net::nym_service::parse_nym_url(&self.url).is_some() || self.transport == 2
+    }
+
     pub(crate) async fn client(&self) -> Result<Client> {
         // Mixnet-native endpoint (nym:// URL, a nym-rpc service): bypasses
         // the transport enum entirely — the mixnet IS the transport.

--- a/rust/src/net/nym_service.rs
+++ b/rust/src/net/nym_service.rs
@@ -24,8 +24,9 @@ use nym_sdk::mixnet::{
     IncludedSurbs, MixnetClient, MixnetClientBuilder, MixnetMessageSender, NymNetworkDetails,
     Recipient,
 };
-use nym_sdk::tcp_proxy::utils::{MessageBuffer, Payload, ProxiedMessage};
-use tokio::net::{TcpListener, TcpStream};
+use nym_sdk::tcp_proxy::utils::{Payload, ProxiedMessage};
+use tokio::io::AsyncWriteExt;
+use tokio::net::{tcp::OwnedWriteHalf, TcpListener, TcpStream};
 use tokio::sync::{oneshot, Mutex, OnceCell};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -152,6 +153,60 @@ async fn get_client() -> Result<MixnetClient> {
     Ok(client)
 }
 
+/// Strictly ordered reassembly buffer for a session's incoming messages.
+///
+/// nym-sdk's `MessageBuffer` flushes any message that has waited longer than
+/// 6s even when earlier ids are still missing ("decay-based delivery"), which
+/// reorders bytes under mixnet retransmission delays and corrupts the h2
+/// stream (GOAWAY FRAME_SIZE_ERROR). gRPC needs exact byte order, so this
+/// buffer only ever writes consecutive message ids; a permanently missing id
+/// is handled by the session stall watchdog instead of by corrupting data.
+struct OrderedMessageBuffer {
+    next_id: u16,
+    pending: HashMap<u16, Payload>,
+    /// Set while writes are blocked on a missing id; cleared on progress.
+    blocked_since: Option<Instant>,
+}
+
+impl OrderedMessageBuffer {
+    fn new() -> Self {
+        OrderedMessageBuffer {
+            next_id: 0,
+            pending: HashMap::new(),
+            blocked_since: None,
+        }
+    }
+
+    fn push(&mut self, msg: ProxiedMessage) {
+        // Ignore duplicates of already-written ids (mixnet retransmissions).
+        if msg.message_id >= self.next_id {
+            self.pending.insert(msg.message_id, msg.message);
+        }
+    }
+
+    /// Write every consecutive payload to the local socket. Returns `true`
+    /// when the session's Close message has been reached.
+    async fn flush(&mut self, write: &mut OwnedWriteHalf) -> Result<bool> {
+        while let Some(payload) = self.pending.remove(&self.next_id) {
+            self.next_id += 1;
+            self.blocked_since = None;
+            match payload {
+                Payload::Data(data) => write.write_all(&data).await?,
+                Payload::Close => return Ok(true),
+            }
+        }
+        if !self.pending.is_empty() && self.blocked_since.is_none() {
+            self.blocked_since = Some(Instant::now());
+        }
+        Ok(false)
+    }
+
+    /// How long writes have been blocked on a missing message id.
+    fn blocked_for(&self) -> Option<Duration> {
+        self.blocked_since.map(|t| t.elapsed())
+    }
+}
+
 /// One ordered mixnet session per local TCP connection, mirroring nym-rpc's
 /// `TcpProxyClient::handle_incoming`.
 async fn run_session(stream: TcpStream, recipient: Recipient) -> Result<()> {
@@ -201,30 +256,39 @@ async fn run_session(stream: TcpStream, recipient: Recipient) -> Result<()> {
         Ok::<_, anyhow::Error>(())
     });
 
-    // Incoming: reorder mixnet messages and write them to the local socket;
-    // after local EOF keep draining for CLOSE_TIMEOUT.
-    let mut msg_buffer = MessageBuffer::new();
+    // Incoming: reorder mixnet messages and write them to the local socket
+    // in strict id order; after local EOF keep draining for CLOSE_TIMEOUT.
+    let mut msg_buffer = OrderedMessageBuffer::new();
     loop {
         tokio::select! {
             _ = &mut rx => break,
             Some(message) = client.next() => {
                 let message = bincode1::deserialize::<ProxiedMessage>(&message.message)?;
                 msg_buffer.push(message);
-                msg_buffer.tick(&mut write).await?;
+                if msg_buffer.flush(&mut write).await? {
+                    tracing::debug!("nym-rpc session {session_id}: Close received");
+                    client.disconnect().await;
+                    return Ok(());
+                }
                 last_in = started.elapsed().as_secs().max(1);
             },
             _ = tokio::time::sleep(Duration::from_millis(100)) => {
-                msg_buffer.tick(&mut write).await?;
                 // Stall: we sent a request after the last reply and the
-                // mixnet has returned nothing since. Drop the session so
-                // the caller gets an error instead of waiting forever.
+                // mixnet has returned nothing since, or replies keep
+                // arriving but a missing id has blocked writes for just as
+                // long. Drop the session so the caller gets an error
+                // instead of waiting forever.
                 let out = last_out.load(Ordering::Relaxed);
-                if out > last_in
+                let request_stalled = out > last_in
                     && started.elapsed().as_secs().saturating_sub(last_in.max(out))
-                        > STALL_TIMEOUT.as_secs()
-                {
+                        > STALL_TIMEOUT.as_secs();
+                let gap_stalled = msg_buffer
+                    .blocked_for()
+                    .is_some_and(|blocked| blocked > STALL_TIMEOUT);
+                if request_stalled || gap_stalled {
                     tracing::warn!(
-                        "nym-rpc session {session_id} stalled (no reply for {}s); closing",
+                        "nym-rpc session {session_id} stalled ({} for {}s); closing",
+                        if gap_stalled { "message gap unfilled" } else { "no reply" },
                         STALL_TIMEOUT.as_secs()
                     );
                     client.disconnect().await;
@@ -238,7 +302,11 @@ async fn run_session(stream: TcpStream, recipient: Recipient) -> Result<()> {
             Some(message) = client.next() => {
                 let message = bincode1::deserialize::<ProxiedMessage>(&message.message)?;
                 msg_buffer.push(message);
-                msg_buffer.tick(&mut write).await?;
+                if msg_buffer.flush(&mut write).await? {
+                    tracing::debug!("nym-rpc session {session_id}: Close received");
+                    client.disconnect().await;
+                    return Ok(());
+                }
             },
             _ = tokio::time::sleep(CLOSE_TIMEOUT) => {
                 tracing::debug!("nym-rpc session {session_id} closed");

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -237,6 +237,10 @@ pub async fn synchronize_impl<S: Sink<SyncProgress> + Send + 'static>(
             )
             .await?;
 
+            // Over the mixnet, download blocks in small chunks so each
+            // GetBlockRange stream fits in one nym-rpc session; elsewhere a
+            // single stream for the whole range is cheaper.
+            let chunk_size = c.is_mixnet().then_some(MIXNET_SYNC_CHUNK);
             shielded_sync(
                 &network,
                 &pool,
@@ -245,6 +249,7 @@ pub async fn synchronize_impl<S: Sink<SyncProgress> + Send + 'static>(
                 start_height,
                 end_height,
                 actions_per_sync,
+                chunk_size,
                 tx_progress.clone(),
                 tx_cancel.subscribe(),
             )
@@ -656,8 +661,69 @@ fn resolve_diversifier_index(
     }
 }
 
+/// Blocks per `GetBlockRange` request when syncing over the Nym mixnet.
+/// A single full-range stream starves the nym-rpc session of reply SURBs
+/// and trips its 120s stall watchdog; small chunks keep each stream within
+/// one session's budget and commit progress between chunks, so a dropped
+/// session only costs the current chunk.
+pub const MIXNET_SYNC_CHUNK: u32 = 1000;
+
 #[allow(clippy::too_many_arguments)]
 pub async fn shielded_sync(
+    network: &Network,
+    pool: &SqlitePool,
+    client: &mut Client,
+    accounts: &[(u32, bool)],
+    start: u32,
+    end: u32,
+    actions_per_sync: u32,
+    chunk_size: Option<u32>,
+    tx_progress: Sender<SyncProgress>,
+    mut rx_cancel: broadcast::Receiver<()>,
+) -> Result<()> {
+    let activation_height: u32 = network
+        .activation_height(NetworkUpgrade::Sapling)
+        .unwrap()
+        .into();
+    let start = start.max(activation_height);
+    let end = end.max(activation_height);
+
+    let chunk_size = chunk_size.unwrap_or(u32::MAX).max(1);
+    let mut chunk_start = start;
+    loop {
+        let chunk_end = chunk_start.saturating_add(chunk_size - 1).min(end);
+        shielded_sync_range(
+            network,
+            pool,
+            client,
+            accounts,
+            chunk_start,
+            chunk_end,
+            actions_per_sync,
+            tx_progress.clone(),
+            rx_cancel.resubscribe(),
+        )
+        .await?;
+        if chunk_end >= end {
+            break;
+        }
+        // A cancel delivered during the finished chunk was consumed by that
+        // chunk's resubscribed receiver; check ours before starting the next.
+        match rx_cancel.try_recv() {
+            Err(broadcast::error::TryRecvError::Empty)
+            | Err(broadcast::error::TryRecvError::Closed) => {}
+            _ => {
+                debug!("Sync cancelled between chunks");
+                break;
+            }
+        }
+        chunk_start = chunk_end + 1;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn shielded_sync_range(
     network: &Network,
     pool: &SqlitePool,
     client: &mut Client,
@@ -668,13 +734,6 @@ pub async fn shielded_sync(
     tx_progress: Sender<SyncProgress>,
     rx_cancel: broadcast::Receiver<()>,
 ) -> Result<()> {
-    let activation_height: u32 = network
-        .activation_height(NetworkUpgrade::Sapling)
-        .unwrap()
-        .into();
-    let start = start.max(activation_height);
-    let end = end.max(activation_height);
-
     let accounts = accounts.to_vec();
     let db_writer_task = {
         let (s, o, i) = get_tree_state(network, client, start - 1).await?;


### PR DESCRIPTION
Large syncs looped forever on "stalled (no reply for 120s)": a single GetBlockRange stream for the whole range starves the nym-rpc session of reply SURBs, and nym-sdk's MessageBuffer flushes messages that waited over 6s even when earlier ids are missing, corrupting the h2 stream (GOAWAY FRAME_SIZE_ERROR) under mixnet retransmission delays.

Over the mixnet, split the shielded sync into 1000-block chunks that each run a complete pass and commit, so a dropped session only costs the chunk in flight; clearnet/Tor keep the single-stream behavior. Replace the decay-based buffer with one that writes strictly consecutive message ids, drops duplicate retransmissions, and honors the server's Close message. A gap left unfilled for 120s trips the stall watchdog instead of hanging the session forever.