### PR TITLE
feat(frost): drive DKG and signing from autosync instead of self-syncing

### DIFF
--- a/lib/pages/dkg.dart
+++ b/lib/pages/dkg.dart
@@ -318,30 +318,48 @@ class DKGPage3 extends ConsumerStatefulWidget {
 
 class DKGPage3State extends ConsumerState<DKGPage3> {
   late final c = coinContext.coin;
-  late final SynchronizerNotifier _synchronizer;
+  // Held in a field because `ref` is unsafe to use once the widget is disposed.
+  late final SynchronizerNotifier _synchronizer =
+      ref.read(synchronizerProvider.notifier);
   String message = "";
   int index = 0;
-  Timer? runTimer;
+  StreamSubscription<int>? _heightSub;
+  int? _lastStepHeight;
+  // Guards against overlapping passes: a slow sync+step must finish before the
+  // next block starts another, or two `doDkg` runs would each publish the same
+  // round and double-spend the funding note.
+  bool _stepping = false;
   bool finished = false;
 
   @override
   void initState() {
     super.initState();
-    // doDkg syncs the DKG accounts itself; keep autosync off the same database
-    // while the rounds run. The notifier is held in a field because `ref` is
-    // unsafe to use from dispose().
-    _synchronizer = ref.read(synchronizerProvider.notifier);
-    _synchronizer.frostInProgress = true;
-    runTimer = Timer.periodic(const Duration(seconds: 30), (_) async {
-      await runDkg();
+    // `doDkg` no longer syncs itself; it steps against what is already synced.
+    // Drive the wallet's synchronizer once per block and then step, rather than
+    // on a fixed timer: the block-height stream delivers the current tip on
+    // subscribe (kicking off round 0) and then only on changes. A round waiting
+    // for its own change to confirm defers to the next block, so
+    // `_lastStepHeight` guards against stepping the same height twice — keeping
+    // the "waiting for funds" warning to at most once per block.
+    _heightSub = blockHeightService.heights.listen((height) async {
+      if (_stepping || _lastStepHeight == height) return;
+      _stepping = true;
+      _lastStepHeight = height;
+      try {
+        // Force a sync of the funding and internal frost accounts (which stores
+        // the incoming package memos), then step against the fresh state.
+        await _synchronizer.syncIfNeeded(height, now: true);
+        if (!mounted) return;
+        await runDkg();
+      } finally {
+        _stepping = false;
+      }
     });
-    unawaited(runDkg());
   }
 
   @override
   void dispose() {
-    runTimer?.cancel();
-    _synchronizer.frostInProgress = false;
+    unawaited(_heightSub?.cancel());
     super.dispose();
   }
 
@@ -349,72 +367,67 @@ class DKGPage3State extends ConsumerState<DKGPage3> {
     try {
       await ref.read(currentHeightProvider.notifier).fetch();
 
-      // No startSynchronize here: doDkg syncs the accounts it needs itself, so
-      // the rounds cannot run on notes a separate sync has not caught up on.
-      final status = doDkg(c: c);
-      status.listen(
-        (s) {
-          if (s is DKGStatus_PublishRound0Pkg) {
-            setState(() {
-              message = "Broadcasting participant keys";
-              index = 0;
-            });
-          }
-          if (s is DKGStatus_WaitRound0Pkg) {
-            setState(() {
-              message = "Waiting for other participants to send their keys";
-              index = 0;
-            });
-          }
-          if (s is DKGStatus_PublishRound1Pkg) {
-            setState(() {
-              message = "Broadcasting round 1 packages";
-              index = 1;
-            });
-          }
-          if (s is DKGStatus_WaitRound1Pkg) {
-            setState(() {
-              message = "Waiting for other participants to send their round 1 packages";
-              index = 1;
-            });
-          }
-          if (s is DKGStatus_PublishRound2Pkg) {
-            setState(() {
-              message = "Broadcasting round 2 packages";
-              index = 2;
-            });
-          }
-          if (s is DKGStatus_WaitRound2Pkg) {
-            setState(() {
-              message = "Waiting for other participants to send their round 2 packages";
-              index = 2;
-            });
-          }
-          if (s is DKGStatus_Finalize) {
-            setState(() {
-              message = "Deriving the shared key";
-              index = 3;
-            });
-          }
-          if (s is DKGStatus_SharedAddress) {
-            final sharedUA = s.field0;
-            ref.invalidate(getAccountsProvider);
-            setState(() {
-              message = "The shared address is: $sharedUA";
-              index = 3;
-              finished = true;
-            });
-          }
-        },
-        onError: (Object e) async {
-          final exc = e as AnyhowException;
-          if (!context.mounted) return;
-          // Transient: the 30s timer retries, so warn instead of a modal error.
-          showWarningSnackbar(exc.message);
-        },
-      );
+      // No startSynchronize here: the block-height handler syncs first, and
+      // doDkg steps against what is already synced. Await the stream to
+      // completion so the handler serializes passes — overlapping doDkg runs
+      // would each publish the same round and double-spend the funding note.
+      await for (final s in doDkg(c: c)) {
+        if (!mounted) return;
+        if (s is DKGStatus_PublishRound0Pkg) {
+          setState(() {
+            message = "Broadcasting participant keys";
+            index = 0;
+          });
+        } else if (s is DKGStatus_WaitRound0Pkg) {
+          setState(() {
+            message = "Waiting for other participants to send their keys";
+            index = 0;
+          });
+        } else if (s is DKGStatus_PublishRound1Pkg) {
+          setState(() {
+            message = "Broadcasting round 1 packages";
+            index = 1;
+          });
+        } else if (s is DKGStatus_WaitRound1Pkg) {
+          setState(() {
+            message = "Waiting for other participants to send their round 1 packages";
+            index = 1;
+          });
+        } else if (s is DKGStatus_PublishRound2Pkg) {
+          setState(() {
+            message = "Broadcasting round 2 packages";
+            index = 2;
+          });
+        } else if (s is DKGStatus_WaitRound2Pkg) {
+          setState(() {
+            message = "Waiting for other participants to send their round 2 packages";
+            index = 2;
+          });
+        } else if (s is DKGStatus_WaitingForFunds) {
+          // The previous round's change is not mined yet, so this round's
+          // publish has nothing to spend. The next block retries; surface it
+          // as a warning rather than failing so the user knows why it paused.
+          showWarningSnackbar(
+            "Waiting for the previous round's change to be confirmed…",
+          );
+        } else if (s is DKGStatus_Finalize) {
+          setState(() {
+            message = "Deriving the shared key";
+            index = 3;
+          });
+        } else if (s is DKGStatus_SharedAddress) {
+          final sharedUA = s.field0;
+          ref.invalidate(getAccountsProvider);
+          setState(() {
+            message = "The shared address is: $sharedUA";
+            index = 3;
+            finished = true;
+          });
+        }
+      }
     } on AnyhowException catch (e) {
       if (!context.mounted) return;
+      // Transient: the next block retries, so warn instead of a modal error.
       showWarningSnackbar(e.message);
     }
   }

--- a/lib/pages/frost.dart
+++ b/lib/pages/frost.dart
@@ -187,30 +187,47 @@ class FrostPage2 extends ConsumerStatefulWidget {
 
 class FrostPage2State extends ConsumerState<FrostPage2> {
   late final c = coinContext.coin;
-  late final SynchronizerNotifier _synchronizer;
+  // Held in a field because `ref` is unsafe to use once the widget is disposed.
+  late final SynchronizerNotifier _synchronizer =
+      ref.read(synchronizerProvider.notifier);
   String message = "";
-  Timer? timer;
+  StreamSubscription<int>? _heightSub;
+  int? _lastStepHeight;
+  // Guards against overlapping passes: a slow sync+step must finish before the
+  // next block starts another, or two `doSign` runs would each spend the same
+  // funding note and double-spend.
+  bool _stepping = false;
   int currentIndex = 0;
   bool finished = false;
 
   @override
   void initState() {
     super.initState();
-    // doSign syncs the accounts it needs; keep autosync off the same database
-    // while the rounds run. The notifier is held in a field because `ref` is
-    // unsafe to use from dispose().
-    _synchronizer = ref.read(synchronizerProvider.notifier);
-    _synchronizer.frostInProgress = true;
-    runFrost();
-    timer = Timer.periodic(Duration(seconds: 30), (_) async {
-      runFrost();
+    // `doSign` no longer syncs itself; it steps against what is already synced.
+    // Drive the wallet's synchronizer once per block and then step: the
+    // block-height stream delivers the current tip on subscribe (kicking off
+    // the first round) and then only on changes. A message waiting for its
+    // change to confirm defers to the next block, so `_lastStepHeight` guards
+    // against stepping the same height twice.
+    _heightSub = blockHeightService.heights.listen((height) async {
+      if (_stepping || _lastStepHeight == height) return;
+      _stepping = true;
+      _lastStepHeight = height;
+      try {
+        // Force a sync of the funding and internal frost accounts (which stores
+        // the incoming message memos), then step against the fresh state.
+        await _synchronizer.syncIfNeeded(height, now: true);
+        if (!mounted) return;
+        await runFrost();
+      } finally {
+        _stepping = false;
+      }
     });
   }
 
   @override
   void dispose() {
-    timer?.cancel();
-    _synchronizer.frostInProgress = false;
+    unawaited(_heightSub?.cancel());
     super.dispose();
   }
 
@@ -226,77 +243,80 @@ class FrostPage2State extends ConsumerState<FrostPage2> {
     );
   }
 
-  void runFrost() async {
+  Future<void> runFrost() async {
     try {
       await ref.read(currentHeightProvider.notifier).fetch();
 
-      // No startSynchronize here: doSign syncs the accounts it needs itself.
-      final status = doSign(c: c);
-      status.listen(
-        (s) {
-          if (s is SigningStatus_WaitingForCommitments) {
-            setState(() {
-              message = "Waiting for other participants to send their commitments";
-              currentIndex = 1; // coordinator
-            });
-          } else if (s is SigningStatus_SendingCommitment) {
-            setState(() {
-              message = "Sending our commitments to the coordinator";
-              currentIndex = 1; // other
-            });
-          } else if (s is SigningStatus_SendingSigningPackage) {
-            setState(() {
-              message = "Broadcasting the signing package to all participants";
-              currentIndex = 2; // coordinator
-            });
-          } else if (s is SigningStatus_WaitingForSigningPackage) {
-            setState(() {
-              message = "Waiting for the signing package from the coordinator";
-              currentIndex = 2; // other
-            });
-          } else if (s is SigningStatus_SendingSignatureShare) {
-            setState(() {
-              message = "Sending our signature share to the coordinator";
-              currentIndex = 3; // other
-            });
-          } else if (s is SigningStatus_SigningCompleted) {
-            setState(() {
-              message = "Signing completed";
-              currentIndex = 3; // other
-              finished = true;
-            });
-          } else if (s is SigningStatus_WaitingForSignatureShares) {
-            setState(() {
-              message = "Waiting for the signature share from the other participants";
-              currentIndex = 2; // coordinator
-            });
-          } else if (s is SigningStatus_PreparingTransaction) {
-            setState(() {
-              message = "Assembling the transaction";
-              currentIndex = 3; // coordinator
-            });
-          } else if (s is SigningStatus_SendingTransaction) {
-            setState(() {
-              message = "Sending the transaction to the network";
-              currentIndex = 3; // coordinator
-            });
-          } else if (s is SigningStatus_TransactionSent) {
-            setState(() {
-              message = "TX ID: ${s.field0}";
-              currentIndex = 3; // coordinator
-              finished = true;
-            });
-          }
-        },
-        onError: (e) async {
-          final exc = e as AnyhowException;
-          if (!context.mounted) return;
-          // Transient: the 30s timer retries, so warn instead of a modal error.
-          showWarningSnackbar(exc.message);
-        },
-      );
+      // No startSynchronize here: the block-height handler syncs first, and
+      // doSign steps against what is already synced. Await the stream to
+      // completion so the handler serializes passes — overlapping doSign runs
+      // would each spend the same funding note and double-spend.
+      await for (final s in doSign(c: c)) {
+        if (!mounted) return;
+        if (s is SigningStatus_WaitingForCommitments) {
+          setState(() {
+            message = "Waiting for other participants to send their commitments";
+            currentIndex = 1; // coordinator
+          });
+        } else if (s is SigningStatus_SendingCommitment) {
+          setState(() {
+            message = "Sending our commitments to the coordinator";
+            currentIndex = 1; // other
+          });
+        } else if (s is SigningStatus_SendingSigningPackage) {
+          setState(() {
+            message = "Broadcasting the signing package to all participants";
+            currentIndex = 2; // coordinator
+          });
+        } else if (s is SigningStatus_WaitingForSigningPackage) {
+          setState(() {
+            message = "Waiting for the signing package from the coordinator";
+            currentIndex = 2; // other
+          });
+        } else if (s is SigningStatus_SendingSignatureShare) {
+          setState(() {
+            message = "Sending our signature share to the coordinator";
+            currentIndex = 3; // other
+          });
+        } else if (s is SigningStatus_SigningCompleted) {
+          setState(() {
+            message = "Signing completed";
+            currentIndex = 3; // other
+            finished = true;
+          });
+        } else if (s is SigningStatus_WaitingForSignatureShares) {
+          setState(() {
+            message = "Waiting for the signature share from the other participants";
+            currentIndex = 2; // coordinator
+          });
+        } else if (s is SigningStatus_PreparingTransaction) {
+          setState(() {
+            message = "Assembling the transaction";
+            currentIndex = 3; // coordinator
+          });
+        } else if (s is SigningStatus_SendingTransaction) {
+          setState(() {
+            message = "Sending the transaction to the network";
+            currentIndex = 3; // coordinator
+          });
+        } else if (s is SigningStatus_TransactionSent) {
+          setState(() {
+            message = "TX ID: ${s.field0}";
+            currentIndex = 3; // coordinator
+            finished = true;
+          });
+        } else if (s is SigningStatus_WaitingForFunds) {
+          // The previous message's change is not mined yet, so this one has
+          // nothing to spend. The next block retries; surface it as a warning
+          // rather than failing.
+          showWarningSnackbar(
+            "Waiting for the previous message's change to be confirmed…",
+          );
+        }
+      }
     } on AnyhowException catch (e) {
       if (!context.mounted) return;
+      // Transient: the next block retries, so warn instead of a modal error.
       showWarningSnackbar(e.message);
     }
   }

--- a/lib/src/rust/api/frost.dart
+++ b/lib/src/rust/api/frost.dart
@@ -11,7 +11,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'pay.dart';
 part 'frost.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `get_funding_account`
+// These functions are ignored because they are not marked as `pub`: `dkg_status_for`, `get_funding_account`, `sync_frost_accounts`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DKGParams`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`
 
@@ -34,6 +34,20 @@ Future<void> initDkg({required Coin c}) =>
 Future<bool> hasDkgAddresses({required Coin c}) =>
     RustLib.instance.api.crateApiFrostHasDkgAddresses(c: c);
 
+/// Advance the DKG by one pass. Does **not** synchronize.
+///
+/// Like the note migration, the DKG depends on the wallet's autosync to advance
+/// the funding and internal frost accounts; the step runs against whatever is
+/// already synced. Syncing was moved out because it must not race the rounds and
+/// autosync already drives the chain forward — the caller retries this on each
+/// new block (`lib/pages/dkg.dart`), and the headless server steps from
+/// `graphql::frost::new_block`, which syncs first.
+///
+/// Each pass executes every effect the planner names until it hits a wait —
+/// one precondition-checked effect at a time. Statuses arrive after the pass,
+/// one per executed task plus the wait it stopped on. A publish that cannot be
+/// funded yet (previous round's change not mined) ends the pass with a
+/// [`DKGStatus::WaitingForFunds`] warning rather than an error.
 Stream<DKGStatus> doDkg({required Coin c}) =>
     RustLib.instance.api.crateApiFrostDoDkg(c: c);
 
@@ -65,6 +79,13 @@ Future<void> initSign(
 Future<bool> isSigningInProgress({required Coin c}) =>
     RustLib.instance.api.crateApiFrostIsSigningInProgress(c: c);
 
+/// Advance the signing rounds by one step. Does **not** synchronize.
+///
+/// Like [`do_dkg`], signing depends on the wallet's autosync to advance the
+/// funding and internal frost accounts; the step runs against what is already
+/// synced and the caller retries on each new block. A signing message that
+/// cannot be funded yet ends the step with a [`SigningStatus::WaitingForFunds`]
+/// warning rather than an error.
 Stream<SigningStatus> doSign({required Coin c}) =>
     RustLib.instance.api.crateApiFrostDoSign(c: c);
 
@@ -85,6 +106,11 @@ sealed class DKGStatus with _$DKGStatus {
   const factory DKGStatus.waitRound1Pkg() = DKGStatus_WaitRound1Pkg;
   const factory DKGStatus.publishRound2Pkg() = DKGStatus_PublishRound2Pkg;
   const factory DKGStatus.waitRound2Pkg() = DKGStatus_WaitRound2Pkg;
+
+  /// A round's package could not be funded yet: the note spent for the
+  /// previous round is locked and its change is not mined. Transient — the
+  /// next block retries. Shown as an info/warning, not an error.
+  const factory DKGStatus.waitingForFunds() = DKGStatus_WaitingForFunds;
   const factory DKGStatus.finalize() = DKGStatus_Finalize;
   const factory DKGStatus.sharedAddress(
     String field0,
@@ -121,6 +147,10 @@ sealed class SigningStatus with _$SigningStatus {
       SigningStatus_SigningCompleted;
   const factory SigningStatus.waitingForSignatureShares() =
       SigningStatus_WaitingForSignatureShares;
+
+  /// A signing message could not be funded yet (previous broadcast's change
+  /// not mined). Transient — the next block retries. Info/warning, not error.
+  const factory SigningStatus.waitingForFunds() = SigningStatus_WaitingForFunds;
   const factory SigningStatus.preparingTransaction() =
       SigningStatus_PreparingTransaction;
   const factory SigningStatus.sendingTransaction() =

--- a/lib/src/rust/api/frost.freezed.dart
+++ b/lib/src/rust/api/frost.freezed.dart
@@ -58,6 +58,7 @@ extension DKGStatusPatterns on DKGStatus {
     TResult Function(DKGStatus_WaitRound1Pkg value)? waitRound1Pkg,
     TResult Function(DKGStatus_PublishRound2Pkg value)? publishRound2Pkg,
     TResult Function(DKGStatus_WaitRound2Pkg value)? waitRound2Pkg,
+    TResult Function(DKGStatus_WaitingForFunds value)? waitingForFunds,
     TResult Function(DKGStatus_Finalize value)? finalize,
     TResult Function(DKGStatus_SharedAddress value)? sharedAddress,
     required TResult orElse(),
@@ -80,6 +81,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg(_that);
       case DKGStatus_WaitRound2Pkg() when waitRound2Pkg != null:
         return waitRound2Pkg(_that);
+      case DKGStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds(_that);
       case DKGStatus_Finalize() when finalize != null:
         return finalize(_that);
       case DKGStatus_SharedAddress() when sharedAddress != null:
@@ -115,6 +118,7 @@ extension DKGStatusPatterns on DKGStatus {
     required TResult Function(DKGStatus_PublishRound2Pkg value)
         publishRound2Pkg,
     required TResult Function(DKGStatus_WaitRound2Pkg value) waitRound2Pkg,
+    required TResult Function(DKGStatus_WaitingForFunds value) waitingForFunds,
     required TResult Function(DKGStatus_Finalize value) finalize,
     required TResult Function(DKGStatus_SharedAddress value) sharedAddress,
   }) {
@@ -136,6 +140,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg(_that);
       case DKGStatus_WaitRound2Pkg():
         return waitRound2Pkg(_that);
+      case DKGStatus_WaitingForFunds():
+        return waitingForFunds(_that);
       case DKGStatus_Finalize():
         return finalize(_that);
       case DKGStatus_SharedAddress():
@@ -165,6 +171,7 @@ extension DKGStatusPatterns on DKGStatus {
     TResult? Function(DKGStatus_WaitRound1Pkg value)? waitRound1Pkg,
     TResult? Function(DKGStatus_PublishRound2Pkg value)? publishRound2Pkg,
     TResult? Function(DKGStatus_WaitRound2Pkg value)? waitRound2Pkg,
+    TResult? Function(DKGStatus_WaitingForFunds value)? waitingForFunds,
     TResult? Function(DKGStatus_Finalize value)? finalize,
     TResult? Function(DKGStatus_SharedAddress value)? sharedAddress,
   }) {
@@ -186,6 +193,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg(_that);
       case DKGStatus_WaitRound2Pkg() when waitRound2Pkg != null:
         return waitRound2Pkg(_that);
+      case DKGStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds(_that);
       case DKGStatus_Finalize() when finalize != null:
         return finalize(_that);
       case DKGStatus_SharedAddress() when sharedAddress != null:
@@ -217,6 +226,7 @@ extension DKGStatusPatterns on DKGStatus {
     TResult Function()? waitRound1Pkg,
     TResult Function()? publishRound2Pkg,
     TResult Function()? waitRound2Pkg,
+    TResult Function()? waitingForFunds,
     TResult Function()? finalize,
     TResult Function(String field0)? sharedAddress,
     required TResult orElse(),
@@ -239,6 +249,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg();
       case DKGStatus_WaitRound2Pkg() when waitRound2Pkg != null:
         return waitRound2Pkg();
+      case DKGStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds();
       case DKGStatus_Finalize() when finalize != null:
         return finalize();
       case DKGStatus_SharedAddress() when sharedAddress != null:
@@ -271,6 +283,7 @@ extension DKGStatusPatterns on DKGStatus {
     required TResult Function() waitRound1Pkg,
     required TResult Function() publishRound2Pkg,
     required TResult Function() waitRound2Pkg,
+    required TResult Function() waitingForFunds,
     required TResult Function() finalize,
     required TResult Function(String field0) sharedAddress,
   }) {
@@ -292,6 +305,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg();
       case DKGStatus_WaitRound2Pkg():
         return waitRound2Pkg();
+      case DKGStatus_WaitingForFunds():
+        return waitingForFunds();
       case DKGStatus_Finalize():
         return finalize();
       case DKGStatus_SharedAddress():
@@ -321,6 +336,7 @@ extension DKGStatusPatterns on DKGStatus {
     TResult? Function()? waitRound1Pkg,
     TResult? Function()? publishRound2Pkg,
     TResult? Function()? waitRound2Pkg,
+    TResult? Function()? waitingForFunds,
     TResult? Function()? finalize,
     TResult? Function(String field0)? sharedAddress,
   }) {
@@ -342,6 +358,8 @@ extension DKGStatusPatterns on DKGStatus {
         return publishRound2Pkg();
       case DKGStatus_WaitRound2Pkg() when waitRound2Pkg != null:
         return waitRound2Pkg();
+      case DKGStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds();
       case DKGStatus_Finalize() when finalize != null:
         return finalize();
       case DKGStatus_SharedAddress() when sharedAddress != null:
@@ -565,6 +583,27 @@ class DKGStatus_WaitRound2Pkg extends DKGStatus {
   @override
   String toString() {
     return 'DKGStatus.waitRound2Pkg()';
+  }
+}
+
+/// @nodoc
+
+class DKGStatus_WaitingForFunds extends DKGStatus {
+  const DKGStatus_WaitingForFunds() : super._();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is DKGStatus_WaitingForFunds);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'DKGStatus.waitingForFunds()';
   }
 }
 
@@ -1028,6 +1067,7 @@ extension SigningStatusPatterns on SigningStatus {
     TResult Function(SigningStatus_SigningCompleted value)? signingCompleted,
     TResult Function(SigningStatus_WaitingForSignatureShares value)?
         waitingForSignatureShares,
+    TResult Function(SigningStatus_WaitingForFunds value)? waitingForFunds,
     TResult Function(SigningStatus_PreparingTransaction value)?
         preparingTransaction,
     TResult Function(SigningStatus_SendingTransaction value)?
@@ -1056,6 +1096,8 @@ extension SigningStatusPatterns on SigningStatus {
       case SigningStatus_WaitingForSignatureShares()
           when waitingForSignatureShares != null:
         return waitingForSignatureShares(_that);
+      case SigningStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds(_that);
       case SigningStatus_PreparingTransaction()
           when preparingTransaction != null:
         return preparingTransaction(_that);
@@ -1097,6 +1139,8 @@ extension SigningStatusPatterns on SigningStatus {
         signingCompleted,
     required TResult Function(SigningStatus_WaitingForSignatureShares value)
         waitingForSignatureShares,
+    required TResult Function(SigningStatus_WaitingForFunds value)
+        waitingForFunds,
     required TResult Function(SigningStatus_PreparingTransaction value)
         preparingTransaction,
     required TResult Function(SigningStatus_SendingTransaction value)
@@ -1120,6 +1164,8 @@ extension SigningStatusPatterns on SigningStatus {
         return signingCompleted(_that);
       case SigningStatus_WaitingForSignatureShares():
         return waitingForSignatureShares(_that);
+      case SigningStatus_WaitingForFunds():
+        return waitingForFunds(_that);
       case SigningStatus_PreparingTransaction():
         return preparingTransaction(_that);
       case SigningStatus_SendingTransaction():
@@ -1155,6 +1201,7 @@ extension SigningStatusPatterns on SigningStatus {
     TResult? Function(SigningStatus_SigningCompleted value)? signingCompleted,
     TResult? Function(SigningStatus_WaitingForSignatureShares value)?
         waitingForSignatureShares,
+    TResult? Function(SigningStatus_WaitingForFunds value)? waitingForFunds,
     TResult? Function(SigningStatus_PreparingTransaction value)?
         preparingTransaction,
     TResult? Function(SigningStatus_SendingTransaction value)?
@@ -1182,6 +1229,8 @@ extension SigningStatusPatterns on SigningStatus {
       case SigningStatus_WaitingForSignatureShares()
           when waitingForSignatureShares != null:
         return waitingForSignatureShares(_that);
+      case SigningStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds(_that);
       case SigningStatus_PreparingTransaction()
           when preparingTransaction != null:
         return preparingTransaction(_that);
@@ -1215,6 +1264,7 @@ extension SigningStatusPatterns on SigningStatus {
     TResult Function()? sendingSignatureShare,
     TResult Function()? signingCompleted,
     TResult Function()? waitingForSignatureShares,
+    TResult Function()? waitingForFunds,
     TResult Function()? preparingTransaction,
     TResult Function()? sendingTransaction,
     TResult Function(String field0)? transactionSent,
@@ -1241,6 +1291,8 @@ extension SigningStatusPatterns on SigningStatus {
       case SigningStatus_WaitingForSignatureShares()
           when waitingForSignatureShares != null:
         return waitingForSignatureShares();
+      case SigningStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds();
       case SigningStatus_PreparingTransaction()
           when preparingTransaction != null:
         return preparingTransaction();
@@ -1275,6 +1327,7 @@ extension SigningStatusPatterns on SigningStatus {
     required TResult Function() sendingSignatureShare,
     required TResult Function() signingCompleted,
     required TResult Function() waitingForSignatureShares,
+    required TResult Function() waitingForFunds,
     required TResult Function() preparingTransaction,
     required TResult Function() sendingTransaction,
     required TResult Function(String field0) transactionSent,
@@ -1295,6 +1348,8 @@ extension SigningStatusPatterns on SigningStatus {
         return signingCompleted();
       case SigningStatus_WaitingForSignatureShares():
         return waitingForSignatureShares();
+      case SigningStatus_WaitingForFunds():
+        return waitingForFunds();
       case SigningStatus_PreparingTransaction():
         return preparingTransaction();
       case SigningStatus_SendingTransaction():
@@ -1325,6 +1380,7 @@ extension SigningStatusPatterns on SigningStatus {
     TResult? Function()? sendingSignatureShare,
     TResult? Function()? signingCompleted,
     TResult? Function()? waitingForSignatureShares,
+    TResult? Function()? waitingForFunds,
     TResult? Function()? preparingTransaction,
     TResult? Function()? sendingTransaction,
     TResult? Function(String field0)? transactionSent,
@@ -1350,6 +1406,8 @@ extension SigningStatusPatterns on SigningStatus {
       case SigningStatus_WaitingForSignatureShares()
           when waitingForSignatureShares != null:
         return waitingForSignatureShares();
+      case SigningStatus_WaitingForFunds() when waitingForFunds != null:
+        return waitingForFunds();
       case SigningStatus_PreparingTransaction()
           when preparingTransaction != null:
         return preparingTransaction();
@@ -1507,6 +1565,27 @@ class SigningStatus_WaitingForSignatureShares extends SigningStatus {
   @override
   String toString() {
     return 'SigningStatus.waitingForSignatureShares()';
+  }
+}
+
+/// @nodoc
+
+class SigningStatus_WaitingForFunds extends SigningStatus {
+  const SigningStatus_WaitingForFunds() : super._();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SigningStatus_WaitingForFunds);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'SigningStatus.waitingForFunds()';
   }
 }
 

--- a/lib/src/rust/api/migrate.dart
+++ b/lib/src/rust/api/migrate.dart
@@ -9,7 +9,8 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'migrate.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `current_migration_status`, `do_step`, `run_migration`, `synchronize_to`, `wait_for_anchor_boundary`, `wallet_height`
+// These functions are ignored because they are not marked as `pub`: `execute`, `observe_state`, `run_migration`, `sample_delay`, `status_from`, `wait_for_next_height`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `Executed`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`
 
 /// Single-shot step (kept for FRB generated-code compatibility).

--- a/lib/src/rust/api/pay.dart
+++ b/lib/src/rust/api/pay.dart
@@ -39,6 +39,12 @@ Future<PcztPackage> signTransaction(
 Future<Uint8List> extractTransaction({required PcztPackage package}) =>
     RustLib.instance.api.crateApiPayExtractTransaction(package: package);
 
+/// Serialize a PCZT for transport between participants.
+///
+/// Uses bincode's `standard()` config so the bytes are interchangeable with
+/// zkool_graphql, whose `prepareSend` / `frostSign` use the same config. The
+/// two used to disagree (`legacy()` here), which made it impossible for an app
+/// user and a zkool_graphql user to co-sign a FROST transaction.
 Future<Uint8List> packTransaction({required PcztPackage pczt}) =>
     RustLib.instance.api.crateApiPayPackTransaction(pczt: pczt);
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -40,6 +40,14 @@ Future<void> rewindSync(
 Future<SyncHeight> getDbHeight({required Coin c}) =>
     RustLib.instance.api.crateApiSyncGetDbHeight(c: c);
 
+/// Decrypt memos and store transaction details for `account`.
+///
+/// Deliberately does NOT take SYNCING. It did briefly, to stop it colliding
+/// with `do_dkg` — but holding the lock here let it starve the next sync, and
+/// `synchronize_impl` reports a skipped sync as success, so the DKG went on to
+/// build a transaction from stale notes and double-spent. Detail fetching is
+/// best effort and its `database is locked` failures are self-healing; a
+/// starved sync is not.
 Future<void> fetchTxDetails({required int account, required Coin c}) =>
     RustLib.instance.api.crateApiSyncFetchTxDetails(account: account, c: c);
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -8711,8 +8711,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 7:
         return DKGStatus_WaitRound2Pkg();
       case 8:
-        return DKGStatus_Finalize();
+        return DKGStatus_WaitingForFunds();
       case 9:
+        return DKGStatus_Finalize();
+      case 10:
         return DKGStatus_SharedAddress(
           dco_decode_String(raw[1]),
         );
@@ -9691,10 +9693,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 6:
         return SigningStatus_WaitingForSignatureShares();
       case 7:
-        return SigningStatus_PreparingTransaction();
+        return SigningStatus_WaitingForFunds();
       case 8:
-        return SigningStatus_SendingTransaction();
+        return SigningStatus_PreparingTransaction();
       case 9:
+        return SigningStatus_SendingTransaction();
+      case 10:
         return SigningStatus_TransactionSent(
           dco_decode_String(raw[1]),
         );
@@ -11085,8 +11089,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 7:
         return DKGStatus_WaitRound2Pkg();
       case 8:
-        return DKGStatus_Finalize();
+        return DKGStatus_WaitingForFunds();
       case 9:
+        return DKGStatus_Finalize();
+      case 10:
         var var_field0 = sse_decode_String(deserializer);
         return DKGStatus_SharedAddress(var_field0);
       default:
@@ -12409,10 +12415,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 6:
         return SigningStatus_WaitingForSignatureShares();
       case 7:
-        return SigningStatus_PreparingTransaction();
+        return SigningStatus_WaitingForFunds();
       case 8:
-        return SigningStatus_SendingTransaction();
+        return SigningStatus_PreparingTransaction();
       case 9:
+        return SigningStatus_SendingTransaction();
+      case 10:
         var var_field0 = sse_decode_String(deserializer);
         return SigningStatus_TransactionSent(var_field0);
       default:
@@ -13933,10 +13941,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(6, serializer);
       case DKGStatus_WaitRound2Pkg():
         sse_encode_i_32(7, serializer);
-      case DKGStatus_Finalize():
+      case DKGStatus_WaitingForFunds():
         sse_encode_i_32(8, serializer);
-      case DKGStatus_SharedAddress(field0: final field0):
+      case DKGStatus_Finalize():
         sse_encode_i_32(9, serializer);
+      case DKGStatus_SharedAddress(field0: final field0):
+        sse_encode_i_32(10, serializer);
         sse_encode_String(field0, serializer);
     }
   }
@@ -14984,12 +14994,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(5, serializer);
       case SigningStatus_WaitingForSignatureShares():
         sse_encode_i_32(6, serializer);
-      case SigningStatus_PreparingTransaction():
+      case SigningStatus_WaitingForFunds():
         sse_encode_i_32(7, serializer);
-      case SigningStatus_SendingTransaction():
+      case SigningStatus_PreparingTransaction():
         sse_encode_i_32(8, serializer);
-      case SigningStatus_TransactionSent(field0: final field0):
+      case SigningStatus_SendingTransaction():
         sse_encode_i_32(9, serializer);
+      case SigningStatus_TransactionSent(field0: final field0):
+        sse_encode_i_32(10, serializer);
         sse_encode_String(field0, serializer);
     }
   }

--- a/lib/store.dart
+++ b/lib/store.dart
@@ -757,11 +757,6 @@ class SynchronizerNotifier extends _$SynchronizerNotifier {
   StreamSubscription<int>? _autoSyncSubscription;
   bool _handlingAutoSyncHeight = false;
   bool _forceNextAutoSync = false;
-  /// While a FROST round is running, autosync must not fire: doDkg/doSign sync
-  /// the accounts they need themselves, and a background sync racing them
-  /// spawns an unawaited fetchTxDetails that writes while the rounds are
-  /// building a transaction — which produced double-spends from stale notes.
-  bool frostInProgress = false;
   int? _pendingAutoSyncHeight;
   StreamSubscription<SyncProgress>? syncProgressSubscription;
   int retryCount = 0;
@@ -938,7 +933,6 @@ class SynchronizerNotifier extends _$SynchronizerNotifier {
   }
 
   void _queueAutoSync(int height, {required bool force}) {
-    if (frostInProgress) return;
     _pendingAutoSyncHeight = max(_pendingAutoSyncHeight ?? height, height);
     _forceNextAutoSync |= force;
     if (_handlingAutoSyncHeight) return;

--- a/rust/src/api/frost.rs
+++ b/rust/src/api/frost.rs
@@ -8,8 +8,11 @@ use sqlx::{query, sqlite::SqliteRow, Row, SqliteConnection};
 
 use crate::{
     api::coin::Coin,
-    frost::dkg::{get_dkg_params, get_mailbox_account},
+    frost::dkg::{
+        get_dkg_params, get_mailbox_account, task::DkgTask,
+    },
     sync::{synchronize_impl, DEFAULT_ACTIONS_PER_SYNC},
+    Sink,
 };
 use std::str::FromStr;
 
@@ -78,28 +81,87 @@ pub async fn has_dkg_addresses(c: &Coin) -> Result<bool> {
 
 #[cfg(feature = "flutter")]
 #[cfg_attr(feature = "flutter", frb)]
-/// Advance the DKG by one step, syncing first.
+/// Advance the DKG by one pass. Does **not** synchronize.
 ///
-/// The sync is done here rather than by the caller so the rounds can never run
-/// on stale notes. The UI used to sync separately before calling this, and that
-/// sync spawned an unawaited `fetch_tx_details` which raced the rounds — see
-/// `api::sync::fetch_tx_details`. This mirrors the headless path, where
-/// `graphql::frost::new_block` syncs and then calls `do_dkg_impl`.
+/// Like the note migration, the DKG depends on the wallet's autosync to advance
+/// the funding and internal frost accounts; the step runs against whatever is
+/// already synced. Syncing was moved out because it must not race the rounds and
+/// autosync already drives the chain forward — the caller retries this on each
+/// new block (`lib/pages/dkg.dart`), and the headless server steps from
+/// `graphql::frost::new_block`, which syncs first.
+///
+/// Each pass executes every effect the planner names until it hits a wait —
+/// one precondition-checked effect at a time. Statuses arrive after the pass,
+/// one per executed task plus the wait it stopped on. A publish that cannot be
+/// funded yet (previous round's change not mined) ends the pass with a
+/// [`DKGStatus::WaitingForFunds`] warning rather than an error.
 pub async fn do_dkg(status: StreamSink<DKGStatus>, c: &Coin) -> Result<()> {
     let mut connection = c.get_connection().await?;
+    // A completed or cancelled DKG must stay silent: the retry keeps firing
+    // after SharedAddress until the page is closed.
+    if !crate::frost::dkg::in_dkg(&mut connection).await? {
+        return Ok(());
+    }
     let mut client = c.client().await?;
     let height = client.latest_height().await?;
     let account = get_funding_account(&mut connection).await?;
 
-    // The funding account pays for the memos; the internal frost-* accounts are
-    // the mailbox and broadcast addresses the packages arrive on.
+    let outcome =
+        crate::frost::dkg::step::dkg_step(&c.network(), &mut connection, &mut client, height, account)
+            .await?;
+    for task in &outcome.executed {
+        if let Some(s) = dkg_status_for(task) {
+            status.send(s).await;
+        }
+    }
+    if outcome.waiting_for_funds {
+        status.send(DKGStatus::WaitingForFunds).await;
+    }
+    if let Some(shared_address) = outcome.shared_address {
+        status.send(DKGStatus::SharedAddress(shared_address)).await;
+    }
+    Ok(())
+}
+
+/// Map a task to the UI status it corresponds to. Publishes and waits map to
+/// their round's variants; the three finalize stages all share `Finalize`.
+fn dkg_status_for(task: &DkgTask) -> Option<DKGStatus> {
+    match task {
+        DkgTask::PublishRound { round: 0 } => Some(DKGStatus::PublishRound0Pkg),
+        DkgTask::PublishRound { round: 1 } => Some(DKGStatus::PublishRound1Pkg),
+        DkgTask::PublishRound { round: 2 } => Some(DKGStatus::PublishRound2Pkg),
+        DkgTask::WaitRound { round: 0 } => Some(DKGStatus::WaitRound0Pkg),
+        DkgTask::WaitRound { round: 1 } => Some(DKGStatus::WaitRound1Pkg),
+        DkgTask::WaitRound { round: 2 } => Some(DKGStatus::WaitRound2Pkg),
+        DkgTask::FinalizeKey | DkgTask::CreateFrostAccount | DkgTask::CompleteFinalize => {
+            Some(DKGStatus::Finalize)
+        }
+        _ => None,
+    }
+}
+
+/// Sync the funding account plus the internal frost-* accounts — the mailbox
+/// and broadcast addresses the protocol messages arrive on. The funding
+/// account pays for the memos. Returns the post-sync height.
+///
+/// `pub(crate)`, not `pub`: it takes a `&mut SqliteConnection` that cannot cross
+/// the flutter_rust_bridge boundary, and only the headless GraphQL server
+/// (`graphql::frost`) drives it — the app relies on its autosync instead. Hence
+/// it is unused (dead) in a flutter-only build.
+#[cfg_attr(not(feature = "graphql"), allow(dead_code))]
+pub(crate) async fn sync_frost_accounts(
+    c: &Coin,
+    connection: &mut SqliteConnection,
+    account: u32,
+    height: u32,
+) -> Result<u32> {
     let mut accounts =
         query("SELECT id_account FROM accounts WHERE name LIKE 'frost-%' AND internal = 1")
             .map(|r: SqliteRow| r.get::<u32, _>(0))
             .fetch_all(&mut *connection)
             .await?;
     accounts.push(account);
-    let height = synchronize_impl(
+    synchronize_impl(
         (),
         accounts,
         height,
@@ -109,21 +171,7 @@ pub async fn do_dkg(status: StreamSink<DKGStatus>, c: &Coin) -> Result<()> {
         false,
         c,
     )
-    .await?;
-
-    let r = crate::frost::dkg::do_dkg(
-        &c.network(),
-        &mut connection,
-        account,
-        &mut client,
-        height,
-        status.clone(),
-    )
-    .await;
-    if let Err(e) = r {
-        let _ = status.add_error(e);
-    }
-    Ok(())
+    .await
 }
 
 pub async fn get_dkg_addresses(c: &Coin) -> Result<Vec<String>> {
@@ -178,6 +226,10 @@ pub enum DKGStatus {
     WaitRound1Pkg,
     PublishRound2Pkg,
     WaitRound2Pkg,
+    /// A round's package could not be funded yet: the note spent for the
+    /// previous round is locked and its change is not mined. Transient — the
+    /// next block retries. Shown as an info/warning, not an error.
+    WaitingForFunds,
     Finalize,
     SharedAddress(String),
 }
@@ -214,34 +266,17 @@ pub async fn is_signing_in_progress(c: &Coin) -> Result<bool> {
 
 #[cfg(feature = "flutter")]
 #[cfg_attr(feature = "flutter", frb)]
-/// Advance the signing rounds by one step, syncing first.
+/// Advance the signing rounds by one step. Does **not** synchronize.
 ///
-/// Syncs here for the same reason as [`do_dkg`]: the rounds must not run on
-/// stale notes, and a caller-side sync spawns an unawaited `fetch_tx_details`
-/// that races them.
+/// Like [`do_dkg`], signing depends on the wallet's autosync to advance the
+/// funding and internal frost accounts; the step runs against what is already
+/// synced and the caller retries on each new block. A signing message that
+/// cannot be funded yet ends the step with a [`SigningStatus::WaitingForFunds`]
+/// warning rather than an error.
 pub async fn do_sign(status: StreamSink<SigningStatus>, c: &Coin) -> Result<()> {
     let mut connection = c.get_connection().await?;
     let mut client = c.client().await?;
     let height = client.latest_height().await?;
-
-    let account = get_funding_account(&mut connection).await?;
-    let mut accounts =
-        query("SELECT id_account FROM accounts WHERE name LIKE 'frost-%' AND internal = 1")
-            .map(|r: SqliteRow| r.get::<u32, _>(0))
-            .fetch_all(&mut *connection)
-            .await?;
-    accounts.push(account);
-    let height = synchronize_impl(
-        (),
-        accounts,
-        height,
-        DEFAULT_ACTIONS_PER_SYNC,
-        1,
-        100,
-        false,
-        c,
-    )
-    .await?;
 
     let r = crate::frost::sign::do_sign(
         &c.network(),
@@ -274,6 +309,9 @@ pub enum SigningStatus {
     SendingSignatureShare,
     SigningCompleted,
     WaitingForSignatureShares,
+    /// A signing message could not be funded yet (previous broadcast's change
+    /// not mined). Transient — the next block retries. Info/warning, not error.
+    WaitingForFunds,
     PreparingTransaction,
     SendingTransaction,
     TransactionSent(String),

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -568,6 +568,14 @@ pub async fn create_schema(connection: &mut SqliteConnection) -> Result<()> {
     .execute(&mut *connection)
     .await?;
 
+    // DKG publish intent: the outgoing package(s) of the round being
+    // published, staged before the broadcast and cleared after it. NULL means
+    // nothing pending (or already sent under an older build). Added without a
+    // DB_VERSION bump: nullable, only read by new code, older builds ignore it.
+    let _ = sqlx::query("ALTER TABLE dkg_state ADD COLUMN pending_publish BLOB")
+        .execute(&mut *connection)
+        .await;
+
     let version = get_prop(connection, "version").await?;
     match version {
         Some(version) if version.parse::<u16>()? > DB_VERSION => {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -9891,9 +9891,12 @@ impl SseDecode for crate::api::frost::DKGStatus {
                 return crate::api::frost::DKGStatus::WaitRound2Pkg;
             }
             8 => {
-                return crate::api::frost::DKGStatus::Finalize;
+                return crate::api::frost::DKGStatus::WaitingForFunds;
             }
             9 => {
+                return crate::api::frost::DKGStatus::Finalize;
+            }
+            10 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::api::frost::DKGStatus::SharedAddress(var_field0);
             }
@@ -11334,12 +11337,15 @@ impl SseDecode for crate::api::frost::SigningStatus {
                 return crate::api::frost::SigningStatus::WaitingForSignatureShares;
             }
             7 => {
-                return crate::api::frost::SigningStatus::PreparingTransaction;
+                return crate::api::frost::SigningStatus::WaitingForFunds;
             }
             8 => {
-                return crate::api::frost::SigningStatus::SendingTransaction;
+                return crate::api::frost::SigningStatus::PreparingTransaction;
             }
             9 => {
+                return crate::api::frost::SigningStatus::SendingTransaction;
+            }
+            10 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::api::frost::SigningStatus::TransactionSent(var_field0);
             }
@@ -13258,9 +13264,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::frost::DKGStatus {
             crate::api::frost::DKGStatus::WaitRound1Pkg => [5.into_dart()].into_dart(),
             crate::api::frost::DKGStatus::PublishRound2Pkg => [6.into_dart()].into_dart(),
             crate::api::frost::DKGStatus::WaitRound2Pkg => [7.into_dart()].into_dart(),
-            crate::api::frost::DKGStatus::Finalize => [8.into_dart()].into_dart(),
+            crate::api::frost::DKGStatus::WaitingForFunds => [8.into_dart()].into_dart(),
+            crate::api::frost::DKGStatus::Finalize => [9.into_dart()].into_dart(),
             crate::api::frost::DKGStatus::SharedAddress(field0) => {
-                [9.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+                [10.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -13970,10 +13977,11 @@ impl flutter_rust_bridge::IntoDart for crate::api::frost::SigningStatus {
             crate::api::frost::SigningStatus::WaitingForSignatureShares => {
                 [6.into_dart()].into_dart()
             }
-            crate::api::frost::SigningStatus::PreparingTransaction => [7.into_dart()].into_dart(),
-            crate::api::frost::SigningStatus::SendingTransaction => [8.into_dart()].into_dart(),
+            crate::api::frost::SigningStatus::WaitingForFunds => [7.into_dart()].into_dart(),
+            crate::api::frost::SigningStatus::PreparingTransaction => [8.into_dart()].into_dart(),
+            crate::api::frost::SigningStatus::SendingTransaction => [9.into_dart()].into_dart(),
             crate::api::frost::SigningStatus::TransactionSent(field0) => {
-                [9.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+                [10.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -15576,11 +15584,14 @@ impl SseEncode for crate::api::frost::DKGStatus {
             crate::api::frost::DKGStatus::WaitRound2Pkg => {
                 <i32>::sse_encode(7, serializer);
             }
-            crate::api::frost::DKGStatus::Finalize => {
+            crate::api::frost::DKGStatus::WaitingForFunds => {
                 <i32>::sse_encode(8, serializer);
             }
-            crate::api::frost::DKGStatus::SharedAddress(field0) => {
+            crate::api::frost::DKGStatus::Finalize => {
                 <i32>::sse_encode(9, serializer);
+            }
+            crate::api::frost::DKGStatus::SharedAddress(field0) => {
+                <i32>::sse_encode(10, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             _ => {
@@ -16680,14 +16691,17 @@ impl SseEncode for crate::api::frost::SigningStatus {
             crate::api::frost::SigningStatus::WaitingForSignatureShares => {
                 <i32>::sse_encode(6, serializer);
             }
-            crate::api::frost::SigningStatus::PreparingTransaction => {
+            crate::api::frost::SigningStatus::WaitingForFunds => {
                 <i32>::sse_encode(7, serializer);
             }
-            crate::api::frost::SigningStatus::SendingTransaction => {
+            crate::api::frost::SigningStatus::PreparingTransaction => {
                 <i32>::sse_encode(8, serializer);
             }
-            crate::api::frost::SigningStatus::TransactionSent(field0) => {
+            crate::api::frost::SigningStatus::SendingTransaction => {
                 <i32>::sse_encode(9, serializer);
+            }
+            crate::api::frost::SigningStatus::TransactionSent(field0) => {
+                <i32>::sse_encode(10, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             _ => {

--- a/rust/src/frost/dkg/exec.rs
+++ b/rust/src/frost/dkg/exec.rs
@@ -1,0 +1,357 @@
+//! Task execution: the side effects, and nothing else.
+//!
+//! Every decision has already been made by the time control reaches here — a
+//! task arrives naming exactly what to do, and these functions carry it out.
+//! The crypto (`dkg::part1/2/3`, the address derivations) is called, never
+//! reimplemented, here.
+//!
+//! The one invariant worth calling out is intent before publish: producing a
+//! round commits the secret **and** the outgoing bytes in one transaction
+//! with no network I/O, and only then does the broadcast go out. A crash
+//! after the send but before the marker is cleared retries the identical
+//! bytes — every peer's `dkg_peers` primary key dedups them — so the
+//! produce-then-publish window that could once wedge a session now costs at
+//! most one wasted fee.
+
+use anyhow::{bail, Context, Result};
+use orchard::keys::{FullViewingKey, Scope};
+use reddsa::frost::redpallas::{
+    frost::keys::PublicKeyPackage,
+    keys::{dkg, EvenY},
+};
+use sqlx::{Connection, SqliteConnection};
+use tracing::info;
+use zcash_keys::address::UnifiedAddress;
+
+use crate::{
+    account::{get_account_seed, get_orchard_vk},
+    api::{coin::Network, frost::DKGParams},
+    db::{delete_account, init_account_orchard, store_account_metadata, store_account_orchard_vk},
+    frost::{Dispatch, FrostBytes, FrostMessage, P, RouteCtx},
+    Client,
+};
+
+use super::{
+    delete_frost_state, get_addresses, get_coordinator_broadcast_account, get_mailbox_account,
+    publish, DkgInit, DkgRound0, DkgRound1, DkgRound2, Round,
+};
+use super::state::{DkgState, PendingPublish};
+
+/// EnsureAccounts: create the private mailbox and the shared broadcast
+/// account if missing. Both helpers are create-if-missing and idempotent.
+pub async fn ensure_accounts(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    account: u32,
+    params: &DKGParams,
+) -> Result<()> {
+    // The broadcast account's seed is a hash over every participant address;
+    // creating it with addresses missing would derive a seed other
+    // participants never find. The planner gates this behind WaitAddresses,
+    // but the guard costs one query and makes the effect safe on its own.
+    let addresses = get_addresses(connection, account, params.n).await?;
+    anyhow::ensure!(
+        addresses.iter().all(|a| !a.is_empty()),
+        "participant addresses incomplete; cannot create the broadcast account"
+    );
+    get_mailbox_account(network, connection, account, params.id, params.birth_height).await?;
+    get_coordinator_broadcast_account(network, connection, account, params.birth_height).await?;
+    Ok(())
+}
+
+/// PublishRound: stage our outgoing package if the round's secret is not
+/// stored yet (secret + staged bytes commit together, before any network
+/// I/O), then send whatever is staged and clear the marker.
+pub async fn publish_round(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    client: &mut Client,
+    account: u32,
+    height: u32,
+    round: u8,
+    state: &DkgState,
+) -> Result<()> {
+    if !state.rounds[round as usize].secret_present {
+        stage(connection, round, account, state).await?;
+    }
+    publish_staged(network, connection, client, account, height, state.params.id).await
+}
+
+/// Produce the round's package and commit it — secret plus outgoing bytes —
+/// in one transaction. No network I/O here.
+async fn stage(
+    connection: &mut SqliteConnection,
+    round: u8,
+    account: u32,
+    state: &DkgState,
+) -> Result<()> {
+    let broadcast_address = state
+        .broadcast_address
+        .clone()
+        .context("broadcast account missing")?;
+    let route_ctx = RouteCtx {
+        broadcast_address: broadcast_address.clone(),
+        coordinator_address: broadcast_address, // unused in DKG
+        peer_addresses: state.addresses.clone(),
+    };
+
+    match round {
+        0 => {
+            let input = DkgInit {
+                self_id: state.params.id,
+                n: state.params.n,
+                t: state.params.t,
+            };
+            let (secret, outgoing) =
+                DkgRound0::produce(&input).context("round 0 produce failed")?;
+            let recipients = outgoing.into_recipients(&route_ctx)?;
+            let mut tx = connection.begin().await?;
+            <DkgRound0 as Round>::store_secret(&mut *tx, account, &secret).await?;
+            store_pending(&mut *tx, account, round, recipients).await?;
+            tx.commit().await?;
+        }
+        1 => {
+            let input = state
+                .state0
+                .as_ref()
+                .context("round 1 input not reconstructed")?;
+            let (secret, outgoing) =
+                DkgRound1::produce(input).context("round 1 produce failed")?;
+            let recipients = outgoing.into_recipients(&route_ctx)?;
+            let mut tx = connection.begin().await?;
+            <DkgRound1 as Round>::store_secret(&mut *tx, account, &secret).await?;
+            store_pending(&mut *tx, account, round, recipients).await?;
+            tx.commit().await?;
+        }
+        2 => {
+            let input = state
+                .state1
+                .as_ref()
+                .context("round 2 input not reconstructed")?;
+            let (secret, outgoing) =
+                DkgRound2::produce(input).context("round 2 produce failed")?;
+            let recipients = outgoing.into_recipients(&route_ctx)?;
+            let mut tx = connection.begin().await?;
+            <DkgRound2 as Round>::store_secret(&mut *tx, account, &secret).await?;
+            store_pending(&mut *tx, account, round, recipients).await?;
+            tx.commit().await?;
+        }
+        _ => bail!("invalid round {round}"),
+    }
+    Ok(())
+}
+
+async fn store_pending(
+    tx: &mut sqlx::SqliteConnection,
+    account: u32,
+    round: u8,
+    recipients: Vec<(String, Vec<u8>)>,
+) -> Result<()> {
+    let pending = PendingPublish { round, recipients };
+    sqlx::query("UPDATE dkg_state SET pending_publish = ?1 WHERE account = ?2")
+        .bind(pending.encode()?)
+        .bind(account)
+        .execute(&mut *tx)
+        .await?;
+    Ok(())
+}
+
+/// Send the staged bytes, if any, and clear the marker only afterwards. A
+/// crash in between retries the identical bytes; peers dedup them.
+async fn publish_staged(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    client: &mut Client,
+    account: u32,
+    height: u32,
+    self_id: u8,
+) -> Result<()> {
+    let pending = load_pending(connection, account).await?;
+    let Some(pending) = pending else {
+        return Ok(());
+    };
+    let prefix = match pending.round {
+        0 => <DkgRound0 as Round>::PREFIX,
+        1 => <DkgRound1 as Round>::PREFIX,
+        2 => <DkgRound2 as Round>::PREFIX,
+        _ => bail!("invalid round {}", pending.round),
+    };
+    let refs: Vec<(&str, Vec<u8>)> = pending
+        .recipients
+        .iter()
+        .map(|(addr, data)| {
+            let msg = FrostMessage {
+                from_id: self_id,
+                data: data.clone(),
+            };
+            Ok((addr.as_str(), msg.encode_with_prefix(&prefix)?))
+        })
+        .collect::<Result<_>>()?;
+    publish(network, connection, account, client, height, &refs)
+        .await
+        .context("publish DKG package")?;
+    sqlx::query("UPDATE dkg_state SET pending_publish = NULL WHERE account = ?")
+        .bind(account)
+        .execute(&mut *connection)
+        .await?;
+    Ok(())
+}
+
+async fn load_pending(
+    connection: &mut SqliteConnection,
+    account: u32,
+) -> Result<Option<PendingPublish>> {
+    sqlx::query_as::<_, (Vec<u8>,)>(
+        "SELECT pending_publish FROM dkg_state WHERE account = ? AND pending_publish IS NOT NULL",
+    )
+    .bind(account)
+    .fetch_optional(&mut *connection)
+    .await?
+    .map(|(b,)| PendingPublish::decode(&b))
+    .transpose()
+}
+
+/// FinalizeKey: derive our key package and the group public key package from
+/// the completed rounds. Idempotent via the stored key package.
+pub async fn finalize_key(
+    connection: &mut SqliteConnection,
+    account: u32,
+    state: &DkgState,
+) -> Result<()> {
+    if state.key_pkg_present {
+        return Ok(());
+    }
+    let state2 = state
+        .state2
+        .as_ref()
+        .context("round 2 not complete; cannot finalize")?;
+    info!(
+        "DKG: calling dkg::part3 (self_id={}, n={}, t={})",
+        state.params.id, state.params.n, state.params.t
+    );
+    let (kp, pp) = dkg::part3(&state2.spkg2, &state2.state1.ppkg1s, &state2.ppkg2s)?;
+    info!("DKG: dkg::part3 completed successfully");
+    sqlx::query("UPDATE dkg_state SET key_pkg = ?1 WHERE account = ?2")
+        .bind(kp.to_bytes()?)
+        .bind(account)
+        .execute(&mut *connection)
+        .await?;
+    sqlx::query(
+        "INSERT INTO dkg_peers(account, round, from_id, data) VALUES(?1, 3, ?2, ?3)
+        ON CONFLICT DO NOTHING",
+    )
+    .bind(account)
+    .bind(state.params.id)
+    .bind(pp.to_bytes()?)
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+/// CreateFrostAccount: build the shared Orchard address by replacing the
+/// spend-auth key in the broadcast account's FVK with the FROST group public
+/// key, then create the frost account holding it. The creation and the
+/// marker recording it commit together, so a crash cannot orphan the account
+/// and re-running cannot duplicate it. Returns the shared address.
+pub async fn create_frost_account(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    account: u32,
+    broadcast_account: u32,
+    height: u32,
+) -> Result<String> {
+    let (pp_data,) = sqlx::query_as::<_, (Vec<u8>,)>(
+        "SELECT data FROM dkg_peers WHERE account = ? AND round = 3 LIMIT 1",
+    )
+    .bind(account)
+    .fetch_one(&mut *connection)
+    .await?;
+    let pub_key_pkg = PublicKeyPackage::<P>::from_bytes(&pp_data)?;
+    let pub_key_pkg = pub_key_pkg.into_even_y(None);
+    let vk = pub_key_pkg.verifying_key();
+    let pkb = vk.serialize().expect("pk serialize");
+
+    let fvk = get_orchard_vk(&mut *connection, broadcast_account)
+        .await?
+        .context("broadcast account vk not found")?;
+    let mut fvkb = fvk.to_bytes();
+    fvkb[0..32].copy_from_slice(&pkb);
+    let shared_fvk = FullViewingKey::from_bytes(&fvkb).expect("Failed to create shared FVK");
+
+    let (name,) = sqlx::query_as::<_, (String,)>(
+        "SELECT name FROM dkg_params WHERE account = ?",
+    )
+    .bind(account)
+    .fetch_one(&mut *connection)
+    .await?;
+
+    let mut tx = connection.begin().await?;
+    let frost_account =
+        store_account_metadata(&mut *tx, &name, &None, &None, height, false, false).await?;
+    init_account_orchard(network, &mut *tx, frost_account, height).await?;
+    store_account_orchard_vk(&mut *tx, frost_account, &shared_fvk).await?;
+    sqlx::query("INSERT OR REPLACE INTO props(key, value) VALUES ('dkg_frost_account', ?1)")
+        .bind(frost_account.to_string())
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    info!("Frost account {frost_account} created with the shared key");
+
+    shared_address(network, connection, frost_account).await
+}
+
+/// The shared address, derived from the frost account's stored group FVK.
+pub async fn shared_address(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    frost_account: u32,
+) -> Result<String> {
+    let fvk = get_orchard_vk(&mut *connection, frost_account)
+        .await?
+        .context("frost account vk not found")?;
+    let address = fvk.address_at(0u64, Scope::External);
+    let ua = UnifiedAddress::from_receivers(Some(address), None, None).unwrap();
+    Ok(ua.encode(network))
+}
+
+/// CompleteFinalize: rekey the protocol rows onto the frost account, record
+/// the mailbox seed, tear down the helper accounts, and only then clear the
+/// props that stop the drivers — a crash mid-teardown must leave the drivers
+/// still willing to step, so the remaining operations re-run idempotently.
+pub async fn complete_finalize(
+    connection: &mut SqliteConnection,
+    funding_account: u32,
+    frost_account: u32,
+    mailbox: Option<u32>,
+    broadcast: Option<u32>,
+) -> Result<()> {
+    // 1. Rekey the protocol rows (no-ops when already done).
+    for table in ["dkg_params", "dkg_state", "dkg_peers", "dkg_addresses"] {
+        sqlx::query(&format!("UPDATE {table} SET account = ?1 WHERE account = ?2"))
+            .bind(frost_account)
+            .bind(funding_account)
+            .execute(&mut *connection)
+            .await?;
+    }
+    // 2. The mailbox seed under the frost account, while the mailbox exists.
+    if let Some(mailbox) = mailbox {
+        let seed = get_account_seed(&mut *connection, mailbox)
+            .await?
+            .context("mailbox seed not found")?
+            .mnemonic;
+        sqlx::query("UPDATE dkg_params SET seed = ?1 WHERE account = ?2")
+            .bind(seed)
+            .bind(frost_account)
+            .execute(&mut *connection)
+            .await?;
+    }
+    // 3. Tear down the helper accounts.
+    if let Some(mailbox) = mailbox {
+        delete_account(&mut *connection, mailbox).await?;
+    }
+    if let Some(broadcast) = broadcast {
+        delete_account(&mut *connection, broadcast).await?;
+    }
+    // 4. Cleanup LAST: the props this deletes are what stop the drivers.
+    delete_frost_state(&mut *connection).await
+}

--- a/rust/src/frost/dkg/mod.rs
+++ b/rust/src/frost/dkg/mod.rs
@@ -2,32 +2,29 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use ed25519_dalek::{SigningKey, VerifyingKey, SECRET_KEY_LENGTH};
-use orchard::keys::{FullViewingKey, Scope};
 use rand_core::OsRng;
 use reddsa::frost::redpallas::{
-    frost::keys::{KeyPackage, PublicKeyPackage},
     keys::dkg::{self, round1, round2},
-    keys::EvenY,
     Identifier,
 };
 use sqlx::{sqlite::SqliteRow, Row, SqliteConnection};
 use tracing::info;
-use zcash_keys::address::UnifiedAddress;
 
 use crate::{
-    account::{get_account_seed, get_orchard_vk},
-    api::{
-        coin::Network,
-        frost::{get_funding_account, DKGParams, DKGStatus},
-        sync::SYNCING,
-    },
-    db::{delete_account, init_account_orchard, store_account_metadata, store_account_orchard_vk},
-    frost::{Broadcast, FrostBytes, PerPeer, Round, RouteCtx},
-    Client, Sink,
+    api::{coin::Network, frost::{get_funding_account, DKGParams}},
+    db::delete_account,
+    frost::{Broadcast, FrostBytes, PerPeer, Round},
+    Client,
 };
 
+pub mod exec;
+pub mod plan;
+pub mod state;
+pub mod step;
+pub mod task;
+
 pub use super::protocol::{
-    get_addresses, get_coordinator_broadcast_account, get_mailbox_account, publish, run_round,
+    get_addresses, get_coordinator_broadcast_account, get_mailbox_account, publish,
 };
 
 // ── FrostBytes for ed25519 types ─────────────────────────────────────────────
@@ -74,6 +71,7 @@ impl FrostBytes for VerifyingKey {
 // ── State types ──────────────────────────────────────────────────────────────
 
 /// Seed data for the first DKG round.
+#[derive(Clone, Copy, Debug)]
 pub struct DkgInit {
     pub self_id: u8,
     pub n: u8,
@@ -81,6 +79,7 @@ pub struct DkgInit {
 }
 
 /// State after round 0 completes: our signing keypair + all peers' public keys.
+#[derive(Clone)]
 pub struct DkgState0 {
     pub init: DkgInit,
     pub signing_key: SigningKey,
@@ -89,6 +88,7 @@ pub struct DkgState0 {
 }
 
 /// State after round 1 completes: our secret + all peers' round-1 packages.
+#[derive(Clone)]
 pub struct DkgState1 {
     pub state0: DkgState0,
     pub spkg1: round1::SecretPackage,
@@ -96,6 +96,7 @@ pub struct DkgState1 {
 }
 
 /// State after round 2 completes: carries forward everything needed for part3.
+#[derive(Clone)]
 pub struct DkgState2 {
     pub state1: DkgState1,
     pub spkg2: round2::SecretPackage,
@@ -114,11 +115,6 @@ impl Round for DkgRound0 {
     type Public = VerifyingKey;
 
     const PREFIX: [u8; 4] = *b"DK00";
-
-    /// Need all other participants' public keys.
-    fn threshold(_n: u8, t: u8) -> usize {
-        t as usize
-    }
 
     fn produce(input: &DkgInit) -> Result<(SigningKey, Broadcast<VerifyingKey>)> {
         info!(
@@ -258,11 +254,6 @@ impl Round for DkgRound1 {
 
     const PREFIX: [u8; 4] = *b"DK11";
 
-    /// Need all other participants' packages.
-    fn threshold(_n: u8, t: u8) -> usize {
-        t as usize
-    }
-
     fn produce(input: &DkgState0) -> Result<(round1::SecretPackage, Broadcast<round1::Package>)> {
         info!(
             "DKG: calling dkg::part1 (self_id={}, n={}, t={})",
@@ -370,11 +361,6 @@ impl Round for DkgRound2 {
     type Public = round2::Package;
 
     const PREFIX: [u8; 4] = *b"DK21";
-
-    /// Need all other participants' packages.
-    fn threshold(_n: u8, t: u8) -> usize {
-        t as usize
-    }
 
     fn produce(input: &DkgState1) -> Result<(round2::SecretPackage, PerPeer<round2::Package>)> {
         // part2 takes spkg1 by value — clone since input is borrowed
@@ -624,278 +610,3 @@ pub async fn delete_frost_state(connection: &mut SqliteConnection) -> Result<()>
     Ok(())
 }
 
-// ── Main orchestrator ────────────────────────────────────────────────────────
-
-#[cfg(feature = "flutter")]
-use crate::frb_generated::StreamSink;
-
-#[cfg(feature = "flutter")]
-pub async fn do_dkg(
-    network: &Network,
-    connection: &mut SqliteConnection,
-    account: u32,
-    client: &mut Client,
-    height: u32,
-    status: StreamSink<DKGStatus>,
-) -> Result<()> {
-    do_dkg_impl(network, connection, account, client, height, status).await
-}
-
-pub async fn do_dkg_impl(
-    network: &Network,
-    connection: &mut SqliteConnection,
-    account: u32,
-    client: &mut Client,
-    height: u32,
-    status: impl Sink<DKGStatus>,
-) -> Result<()> {
-    info!("dkg: {account}");
-
-    let guard = SYNCING.try_lock();
-    if guard.is_err() {
-        return Ok(());
-    }
-
-    let DKGParams {
-        id: self_id,
-        n,
-        t,
-        birth_height,
-    } = get_dkg_params(connection, account).await?;
-
-    let (mailbox_account, _) =
-        get_mailbox_account(network, connection, account, self_id, birth_height).await?;
-    let (broadcast_account, broadcast_address) =
-        get_coordinator_broadcast_account(network, connection, account, birth_height).await?;
-
-    let addresses = get_addresses(connection, account, n).await?;
-    let route_ctx = RouteCtx {
-        broadcast_address: broadcast_address.clone(),
-        coordinator_address: broadcast_address.clone(), // unused in DKG
-        peer_addresses: addresses,
-    };
-
-    // ── Round 0: broadcast signing public keys ────────────────────────────────
-    // `run_round` publishes our own package only on the invocation where our
-    // secret does not exist yet, so checking for it first tells us whether this
-    // pass is a broadcast or just a poll for peer packages.
-    let init = DkgInit { self_id, n, t };
-    if <DkgRound0 as Round>::load_secret(connection, account)
-        .await?
-        .is_none()
-    {
-        status.send(DKGStatus::PublishRound0Pkg).await;
-    }
-    let Some(state0) = run_round::<DkgRound0>(
-        connection,
-        account,
-        n,
-        t,
-        self_id,
-        account,           // funding_account
-        broadcast_account, // incoming memos arrive at broadcast
-        init,
-        &route_ctx,
-        network,
-        client,
-        height,
-    )
-    .await?
-    else {
-        status.send(DKGStatus::WaitRound0Pkg).await;
-        return Ok(());
-    };
-    info!(
-        "Round 0 complete - collected {} peer signing keys",
-        state0.peer_verifying_keys.len()
-    );
-
-    // ── Round 1: everyone broadcasts one package to the shared address ────────
-    if <DkgRound1 as Round>::load_secret(connection, account)
-        .await?
-        .is_none()
-    {
-        status.send(DKGStatus::PublishRound1Pkg).await;
-    }
-    let Some(state1) = run_round::<DkgRound1>(
-        connection,
-        account,
-        n,
-        t,
-        self_id,
-        account,           // funding_account
-        broadcast_account, // incoming memos arrive at broadcast
-        state0,
-        &route_ctx,
-        network,
-        client,
-        height,
-    )
-    .await?
-    else {
-        status.send(DKGStatus::WaitRound1Pkg).await;
-        return Ok(());
-    };
-    info!("Round 1 complete");
-
-    // ── Round 2: each sends a unique package to every peer's mailbox ──────────
-    if <DkgRound2 as Round>::load_secret(connection, account)
-        .await?
-        .is_none()
-    {
-        status.send(DKGStatus::PublishRound2Pkg).await;
-    }
-    let Some(state2) = run_round::<DkgRound2>(
-        connection,
-        account,
-        n,
-        t,
-        self_id,
-        account,         // funding_account
-        mailbox_account, // incoming memos arrive at our private mailbox
-        state1,
-        &route_ctx,
-        network,
-        client,
-        height,
-    )
-    .await?
-    else {
-        status.send(DKGStatus::WaitRound2Pkg).await;
-        return Ok(());
-    };
-    info!("Round 2 complete");
-
-    // ── Round 3: local only — derive the shared key ───────────────────────────
-    status.send(DKGStatus::Finalize).await;
-    let key_pkg = sqlx::query_as::<_, (Vec<u8>,)>(
-        "SELECT key_pkg FROM dkg_state WHERE account = ? AND key_pkg IS NOT NULL",
-    )
-    .bind(account)
-    .fetch_optional(&mut *connection)
-    .await?;
-
-    let (key_pkg, pub_key_pkg) = if let Some((data,)) = key_pkg {
-        // Already computed on a previous block — reload from DB
-        let kp = KeyPackage::<_>::from_bytes(&data)?;
-        let (pp_data,) = sqlx::query_as::<_, (Vec<u8>,)>(
-            "SELECT data FROM dkg_peers WHERE account = ? AND round = 3 LIMIT 1",
-        )
-        .bind(account)
-        .fetch_one(&mut *connection)
-        .await?;
-        (kp, PublicKeyPackage::from_bytes(&pp_data)?)
-    } else {
-        info!(
-            "DKG: calling dkg::part3 (self_id={}, n={}, t={})",
-            self_id, n, t
-        );
-        let (kp, pp) = dkg::part3(&state2.spkg2, &state2.state1.ppkg1s, &state2.ppkg2s)?;
-        info!("DKG: dkg::part3 completed successfully");
-        sqlx::query("UPDATE dkg_state SET key_pkg = ?1 WHERE account = ?2")
-            .bind(kp.to_bytes()?)
-            .bind(account)
-            .execute(&mut *connection)
-            .await?;
-        sqlx::query(
-            "INSERT INTO dkg_peers(account, round, from_id, data) VALUES(?1, 3, ?2, ?3)
-            ON CONFLICT DO NOTHING",
-        )
-        .bind(account)
-        .bind(self_id)
-        .bind(pp.to_bytes()?)
-        .execute(&mut *connection)
-        .await?;
-        (kp, pp)
-    };
-
-    // Build the shared Orchard address by replacing the spend-auth key in the
-    // broadcast account's FVK with the FROST group public key.
-    let fvk = get_orchard_vk(connection, broadcast_account)
-        .await?
-        .expect("broadcast account vk not found");
-    let mut fvkb = fvk.to_bytes();
-    let pub_key_pkg = pub_key_pkg.into_even_y(None);
-    let vk = pub_key_pkg.verifying_key();
-    let pkb = vk.serialize().expect("pk serialize");
-    fvkb[0..32].copy_from_slice(&pkb);
-    let shared_fvk = FullViewingKey::from_bytes(&fvkb).expect("Failed to create shared FVK");
-    let address = shared_fvk.address_at(0u64, Scope::External);
-    let ua = UnifiedAddress::from_receivers(Some(address), None, None).unwrap();
-    let sua = ua.encode(network);
-    info!("Shared address: {sua}");
-
-    let (name,) = sqlx::query_as::<_, (String,)>("SELECT name FROM dkg_params WHERE account = ?")
-        .bind(account)
-        .fetch_one(&mut *connection)
-        .await?;
-    let frost_account =
-        store_account_metadata(connection, &name, &None, &None, height, false, false).await?;
-    init_account_orchard(network, connection, frost_account, height).await?;
-    store_account_orchard_vk(connection, frost_account, &shared_fvk).await?;
-
-    dkg_finalize(
-        connection,
-        account,
-        frost_account,
-        mailbox_account,
-        broadcast_account,
-    )
-    .await?;
-
-    // Store key material under the frost account
-    sqlx::query("UPDATE dkg_state SET key_pkg = ?1 WHERE account = ?2")
-        .bind(key_pkg.to_bytes()?)
-        .bind(frost_account)
-        .execute(&mut *connection)
-        .await?;
-
-    status.send(DKGStatus::SharedAddress(sua)).await;
-
-    cancel_dkg(connection, account).await?;
-    Ok(())
-}
-
-async fn dkg_finalize(
-    connection: &mut SqliteConnection,
-    account: u32,
-    frost_account: u32,
-    mailbox_account: u32,
-    broadcast_account: u32,
-) -> Result<()> {
-    sqlx::query("UPDATE dkg_params SET account = ?1 WHERE account = ?2")
-        .bind(frost_account)
-        .bind(account)
-        .execute(&mut *connection)
-        .await?;
-    sqlx::query("UPDATE dkg_state SET account = ?1 WHERE account = ?2")
-        .bind(frost_account)
-        .bind(account)
-        .execute(&mut *connection)
-        .await?;
-    sqlx::query("UPDATE dkg_peers SET account = ?1 WHERE account = ?2")
-        .bind(frost_account)
-        .bind(account)
-        .execute(&mut *connection)
-        .await?;
-    sqlx::query("UPDATE dkg_addresses SET account = ?1 WHERE account = ?2")
-        .bind(frost_account)
-        .bind(account)
-        .execute(&mut *connection)
-        .await?;
-    sqlx::query("DELETE FROM props WHERE key LIKE 'dkg_%'")
-        .execute(&mut *connection)
-        .await?;
-    let seed = get_account_seed(&mut *connection, mailbox_account)
-        .await?
-        .expect("mailbox seed not found")
-        .mnemonic;
-    sqlx::query("UPDATE dkg_params SET seed = ?1 WHERE account = ?2")
-        .bind(seed)
-        .bind(frost_account)
-        .execute(&mut *connection)
-        .await?;
-    delete_account(&mut *connection, mailbox_account).await?;
-    delete_account(&mut *connection, broadcast_account).await?;
-    Ok(())
-}

--- a/rust/src/frost/dkg/plan.rs
+++ b/rust/src/frost/dkg/plan.rs
@@ -1,0 +1,210 @@
+//! Pure decision logic for the DKG pipeline.
+//!
+//! Nothing here performs I/O. Every function is a total function of its
+//! arguments, so what the DKG decides to do can be unit-tested without a
+//! wallet, a chain, or other participants.
+
+use super::state::DkgState;
+use super::task::DkgTask;
+
+/// Decide the DKG's next step.
+///
+/// Pure: a total function of observed protocol state. Rounds advance only
+/// when every participant's package has arrived — the all-n discipline that
+/// keeps every wallet's materialized key set identical, so any t-subset is
+/// valid when signing begins.
+pub fn next_task(s: &DkgState) -> DkgTask {
+    if !s.addresses_complete() {
+        return DkgTask::WaitAddresses;
+    }
+    if s.mailbox.is_none() || s.broadcast.is_none() {
+        return DkgTask::EnsureAccounts;
+    }
+    // A staged-but-unsent publish outranks everything: resending exactly
+    // those bytes is the crash-recovery path, and every peer dedups them.
+    if let Some(round) = s.pending_round() {
+        return DkgTask::PublishRound { round };
+    }
+    for round in 0..3u8 {
+        let rs = &s.rounds[round as usize];
+        if !rs.secret_present {
+            return DkgTask::PublishRound { round };
+        }
+        if rs.others < s.params.n.saturating_sub(1) {
+            return DkgTask::WaitRound { round };
+        }
+    }
+    if !s.key_pkg_present {
+        return DkgTask::FinalizeKey;
+    }
+    if s.frost_account.is_none() {
+        return DkgTask::CreateFrostAccount;
+    }
+    DkgTask::CompleteFinalize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::frost::DKGParams;
+    use crate::frost::dkg::state::RoundState;
+
+    fn params(n: u8) -> DKGParams {
+        DKGParams {
+            id: 1,
+            n,
+            t: 2,
+            birth_height: 0,
+        }
+    }
+
+    fn round(secret: bool, others: u8) -> RoundState {
+        RoundState {
+            secret_present: secret,
+            others,
+            pending: None,
+        }
+    }
+
+    /// A wallet with all addresses exchanged, both helper accounts present.
+    fn state(n: u8, rounds: [RoundState; 3]) -> DkgState {
+        DkgState {
+            funding_account: 1,
+            params: params(n),
+            addresses: vec!["a".to_string(); n as usize],
+            mailbox: Some(100),
+            broadcast: Some(101),
+            broadcast_address: Some("b".into()),
+            rounds,
+            key_pkg_present: false,
+            frost_account: None,
+            rekeyed: false,
+            state0: None,
+            state1: None,
+            state2: None,
+        }
+    }
+
+    /// Rounds 0..=`last` have secrets and all n-1 peer packages.
+    fn through(n: u8, last: u8) -> [RoundState; 3] {
+        let mut rounds = [round(false, 0); 3];
+        for (i, r) in rounds.iter_mut().enumerate() {
+            if i <= last as usize {
+                *r = round(true, n - 1);
+            }
+        }
+        rounds
+    }
+
+    #[test]
+    fn waits_for_all_addresses() {
+        let mut s = state(3, through(3, 2));
+        s.addresses[1] = String::new();
+        assert_eq!(next_task(&s), DkgTask::WaitAddresses);
+    }
+
+    #[test]
+    fn ensures_accounts_before_anything_else() {
+        let mut s = state(3, through(3, 2));
+        s.broadcast = None;
+        s.broadcast_address = None;
+        assert_eq!(next_task(&s), DkgTask::EnsureAccounts);
+    }
+
+    #[test]
+    fn pending_publish_outranks_producing_the_next_round() {
+        let mut s = state(3, through(3, 0));
+        s.rounds[0].pending = Some(0);
+        assert_eq!(next_task(&s), DkgTask::PublishRound { round: 0 });
+    }
+
+    /// Regression: rounds used to advance once t packages had arrived, which
+    /// with t < n finalized each wallet on a nondeterministic subset of the
+    /// key material. All n participants run the DKG, so every round waits
+    /// for all n-1 peers.
+    #[test]
+    fn rounds_wait_for_all_participants() {
+        let s = state(
+            3,
+            {
+                let mut r = [round(false, 0); 3];
+                r[0] = round(true, 1); // only 1 of 2 peers so far
+                r
+            },
+        );
+        assert_eq!(next_task(&s), DkgTask::WaitRound { round: 0 });
+    }
+
+    #[test]
+    fn produces_rounds_in_order() {
+        assert_eq!(
+            next_task(&state(3, [round(false, 0); 3])),
+            DkgTask::PublishRound { round: 0 }
+        );
+        assert_eq!(
+            next_task(&state(3, through(3, 0))),
+            DkgTask::PublishRound { round: 1 }
+        );
+        assert_eq!(
+            next_task(&state(3, through(3, 1))),
+            DkgTask::PublishRound { round: 2 }
+        );
+    }
+
+    #[test]
+    fn finalizes_in_stages() {
+        let s = state(3, through(3, 2));
+        assert_eq!(next_task(&s), DkgTask::FinalizeKey);
+        let mut s2 = s.clone();
+        s2.key_pkg_present = true;
+        assert_eq!(next_task(&s2), DkgTask::CreateFrostAccount);
+        let mut s3 = s2.clone();
+        s3.frost_account = Some(7);
+        assert_eq!(next_task(&s3), DkgTask::CompleteFinalize);
+    }
+
+    /// A wallet the rekey already moved to the frost account must resume
+    /// with the cleanup, not start over.
+    #[test]
+    fn rekeyed_wallet_finishes_the_cleanup() {
+        let mut s = state(3, through(3, 2));
+        s.rekeyed = true;
+        s.key_pkg_present = true;
+        s.frost_account = Some(7);
+        assert_eq!(next_task(&s), DkgTask::CompleteFinalize);
+    }
+
+    #[test]
+    fn preconditions_reject_stale_plans() {
+        let s = state(3, through(3, 0));
+
+        // Round 1 not produced yet: staging is due.
+        assert!(DkgTask::PublishRound { round: 1 }.is_satisfied_by(&s));
+        // Published (secret stored, nothing staged): re-publishing is stale.
+        let mut published = s.clone();
+        published.rounds[1].secret_present = true;
+        assert!(!DkgTask::PublishRound { round: 1 }.is_satisfied_by(&published));
+        // Staged but unconfirmed: resending the staged bytes is the point.
+        published.rounds[1].pending = Some(1);
+        assert!(DkgTask::PublishRound { round: 1 }.is_satisfied_by(&published));
+
+        assert!(DkgTask::FinalizeKey.is_satisfied_by(&s));
+        let mut done_key = s.clone();
+        done_key.key_pkg_present = true;
+        assert!(!DkgTask::FinalizeKey.is_satisfied_by(&done_key));
+
+        assert!(DkgTask::CreateFrostAccount.is_satisfied_by(&s));
+        let mut acc = s.clone();
+        acc.frost_account = Some(7);
+        assert!(!DkgTask::CreateFrostAccount.is_satisfied_by(&acc));
+
+        assert!(!DkgTask::EnsureAccounts.is_satisfied_by(&s));
+        let mut noacc = s.clone();
+        noacc.mailbox = None;
+        assert!(DkgTask::EnsureAccounts.is_satisfied_by(&noacc));
+
+        assert!(DkgTask::WaitRound { round: 0 }.is_satisfied_by(&s));
+        assert!(DkgTask::WaitAddresses.is_satisfied_by(&s));
+        assert!(DkgTask::CompleteFinalize.is_satisfied_by(&s));
+    }
+}

--- a/rust/src/frost/dkg/state.rs
+++ b/rust/src/frost/dkg/state.rs
@@ -1,0 +1,286 @@
+//! A snapshot of everything the DKG needs in order to decide what to do.
+//!
+//! `observe` is the DKG's single reader of protocol state. Unlike the note
+//! migration's observation, it is not purely read-only: it first ingests the
+//! peer packages that have arrived in memos since the last step. That ingest
+//! is idempotent — `dkg_peers`' primary key `(account, round, from_id)` dedups
+//! — and it is what makes peer progress visible: in a multi-party protocol,
+//! the state that decides the next task lives partly in other wallets'
+//! messages.
+
+use anyhow::{bail, Context, Result};
+use bincode::{config, Decode, Encode};
+use sqlx::{Row, SqliteConnection};
+
+use crate::api::{coin::Network, frost::DKGParams};
+use crate::frost::protocol::{decode_dkg_memos, get_addresses, lookup_broadcast_account};
+
+use super::{DkgRound0, DkgRound1, DkgRound2, DkgInit, DkgState0, DkgState1, DkgState2, Round};
+
+/// Outgoing bytes staged before the broadcast, cleared after it. Routing is
+/// frozen at stage time so a retry sends exactly what was planned. The crash
+/// window between `send` and clearing the marker only ever costs one
+/// duplicate memo transmission — the identical bytes, deduplicated by every
+/// peer's primary key — never a secret/package mismatch.
+#[derive(Encode, Decode)]
+pub struct PendingPublish {
+    pub round: u8,
+    pub recipients: Vec<(String, Vec<u8>)>,
+}
+
+impl PendingPublish {
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        Ok(bincode::encode_to_vec(self, config::legacy())?)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        Ok(bincode::decode_from_slice(data, config::legacy())?.0)
+    }
+}
+
+/// Where one round stands: our secret, the peers we have heard from, and
+/// whether an outgoing package is staged but not yet confirmed sent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RoundState {
+    pub secret_present: bool,
+    /// Distinct packages from participants other than us.
+    pub others: u8,
+    /// Round whose outgoing bytes are staged in `dkg_state.pending_publish`.
+    pub pending: Option<u8>,
+}
+
+/// The wallet's DKG state at one instant, as the planner sees it.
+#[derive(Clone)]
+pub struct DkgState {
+    pub funding_account: u32,
+    pub params: DKGParams,
+    /// Participant addresses, slot `id - 1` empty when not yet exchanged.
+    pub addresses: Vec<String>,
+    pub mailbox: Option<u32>,
+    pub broadcast: Option<u32>,
+    pub broadcast_address: Option<String>,
+    pub rounds: [RoundState; 3],
+    pub key_pkg_present: bool,
+    /// The shared frost account, once created (props `dkg_frost_account`).
+    pub frost_account: Option<u32>,
+    /// True when `dkg_params` was found under the frost account: the finalize
+    /// rekey already happened and only cleanup remains.
+    pub rekeyed: bool,
+    // Reconstructed round inputs (pure `collect` chains), consumed by exec.
+    pub state0: Option<DkgState0>,
+    pub state1: Option<DkgState1>,
+    pub state2: Option<DkgState2>,
+}
+
+impl DkgState {
+    pub fn addresses_complete(&self) -> bool {
+        self.addresses.len() == self.params.n as usize
+            && self.addresses.iter().all(|a| !a.is_empty())
+    }
+
+    /// The round with staged-but-unsent outgoing bytes, if any.
+    pub fn pending_round(&self) -> Option<u8> {
+        self.rounds
+            .iter()
+            .position(|r| r.pending.is_some())
+            .map(|r| r as u8)
+    }
+}
+
+/// Read protocol state. Peer packages are ingested from memos first; the
+/// rest is a handful of queries over the dkg_* tables plus the two helper
+/// accounts, and the pure `collect` chain that rebuilds the round inputs.
+pub async fn observe(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    funding_account: u32,
+) -> Result<DkgState> {
+    // Resolve which account's rows we are on: the funding account until the
+    // finalize rekey, the frost account after it. props `dkg_frost_account`
+    // bridges the gap so a crash inside finalize resumes instead of failing.
+    let frost_account: Option<u32> = sqlx::query_as::<_, (String,)>(
+        "SELECT value FROM props WHERE key = 'dkg_frost_account'",
+    )
+    .fetch_optional(&mut *connection)
+    .await?
+    .and_then(|(v,)| v.parse().ok());
+
+    let (params, params_account, rekeyed) = match get_params_opt(connection, funding_account).await?
+    {
+        Some(p) => (p, funding_account, false),
+        None => match frost_account {
+            Some(fa) => match get_params_opt(connection, fa).await? {
+                Some(p) => (p, fa, true),
+                None => bail!("dkg_params not found for account {funding_account}"),
+            },
+            None => bail!("dkg_params not found for account {funding_account}"),
+        },
+    };
+
+    let n = params.n;
+    let addresses = get_addresses(connection, params_account, n).await?;
+    let addresses_complete = addresses.len() == n as usize && addresses.iter().all(|a| !a.is_empty());
+
+    // Helper accounts, looked up read-only — creating them is an effect
+    // (EnsureAccounts), and observe has no side effects beyond memo ingest.
+    let mailbox = mailbox_account_id(connection, params_account).await?;
+    let broadcast_lookup = if addresses_complete {
+        lookup_broadcast_account(network, connection, params_account).await?
+    } else {
+        None
+    };
+    let (broadcast, broadcast_address) = match broadcast_lookup {
+        Some((id, addr)) => (Some(id), Some(addr)),
+        None => (None, None),
+    };
+
+    // Ingest arrived peer packages. Rounds 0 and 1 are broadcast to the
+    // shared address, round 2 to our private mailbox; ingest whichever
+    // accounts exist (a missing account has nothing to read yet).
+    if let Some(broadcast_id) = broadcast {
+        decode_dkg_memos::<DkgRound0>(connection, params_account, broadcast_id).await?;
+        decode_dkg_memos::<DkgRound1>(connection, params_account, broadcast_id).await?;
+    }
+    if let Some(mailbox_id) = mailbox {
+        decode_dkg_memos::<DkgRound2>(connection, params_account, mailbox_id).await?;
+    }
+
+    let pending: Option<PendingPublish> =
+        sqlx::query_as::<_, (Vec<u8>,)>(
+            "SELECT pending_publish FROM dkg_state WHERE account = ? AND pending_publish IS NOT NULL",
+        )
+        .bind(params_account)
+        .fetch_optional(&mut *connection)
+        .await?
+        .map(|(b,)| PendingPublish::decode(&b))
+        .transpose()?;
+
+    let mut rounds = [RoundState { secret_present: false, others: 0, pending: None }; 3];
+    for (round, rs) in rounds.iter_mut().enumerate() {
+        let round = round as u8;
+        rs.secret_present = match round {
+            0 => <DkgRound0 as Round>::load_secret(connection, params_account).await?.is_some(),
+            1 => <DkgRound1 as Round>::load_secret(connection, params_account).await?.is_some(),
+            _ => <DkgRound2 as Round>::load_secret(connection, params_account).await?.is_some(),
+        };
+        rs.others = sqlx::query_as::<_, (u32,)>(
+            "SELECT COUNT(*) FROM dkg_peers WHERE account = ? AND round = ? AND from_id != ?",
+        )
+        .bind(params_account)
+        .bind(round)
+        .bind(params.id)
+        .fetch_one(&mut *connection)
+        .await?
+        .0 as u8;
+        rs.pending = pending
+            .as_ref()
+            .filter(|p| p.round == round)
+            .map(|p| p.round);
+    }
+
+    let key_pkg_present = sqlx::query_as::<_, (Vec<u8>,)>(
+        "SELECT key_pkg FROM dkg_state WHERE account = ? AND key_pkg IS NOT NULL",
+    )
+    .bind(params_account)
+    .fetch_optional(&mut *connection)
+    .await?
+    .is_some();
+
+    // Rebuild the round inputs by chaining the pure `collect` functions over
+    // stored secrets and peer packages — the same data `do_dkg_impl` used to
+    // thread through `run_round` return values, re-derived from the DB each
+    // step instead.
+    let init = DkgInit {
+        self_id: params.id,
+        n,
+        t: params.t,
+    };
+    let need_peers = |rs: &RoundState| rs.secret_present && rs.others >= n.saturating_sub(1);
+    let state0 = if need_peers(&rounds[0]) {
+        let secret = <DkgRound0 as Round>::load_secret(connection, params_account)
+            .await?
+            .unwrap();
+        let peers = <DkgRound0 as Round>::load_publics(connection, params_account).await?;
+        Some(DkgRound0::collect(init, secret, peers)?)
+    } else {
+        None
+    };
+    let state1 = if let (Some(s0), true) = (&state0, need_peers(&rounds[1])) {
+        let secret = <DkgRound1 as Round>::load_secret(connection, params_account)
+            .await?
+            .unwrap();
+        let peers = <DkgRound1 as Round>::load_publics(connection, params_account).await?;
+        Some(DkgRound1::collect(s0.clone(), secret, peers)?)
+    } else {
+        None
+    };
+    let state2 = if let (Some(s1), true) = (&state1, need_peers(&rounds[2])) {
+        let secret = <DkgRound2 as Round>::load_secret(connection, params_account)
+            .await?
+            .unwrap();
+        let peers = <DkgRound2 as Round>::load_publics(connection, params_account).await?;
+        Some(DkgRound2::collect(s1.clone(), secret, peers)?)
+    } else {
+        None
+    };
+
+    Ok(DkgState {
+        funding_account,
+        params,
+        addresses,
+        mailbox,
+        broadcast,
+        broadcast_address,
+        rounds,
+        key_pkg_present,
+        frost_account,
+        rekeyed,
+        state0,
+        state1,
+        state2,
+    })
+}
+
+/// The dkg_params row, if present. Unlike [`super::get_dkg_params`], missing
+/// rows are a normal outcome: they mean the finalize rekey already moved the
+/// row to the frost account.
+async fn get_params_opt(
+    connection: &mut SqliteConnection,
+    account: u32,
+) -> Result<Option<DKGParams>> {
+    sqlx::query("SELECT id, n, t, birth_height FROM dkg_params WHERE account = ?")
+        .bind(account)
+        .map(|row: sqlx::sqlite::SqliteRow| DKGParams {
+            id: row.get(0),
+            n: row.get(1),
+            t: row.get(2),
+            birth_height: row.get(3),
+        })
+        .fetch_optional(&mut *connection)
+        .await
+        .context("Fetch dkg_params")
+}
+
+/// The private mailbox account, found by the seed stored in dkg_params when
+/// it was created. None when the mailbox does not exist yet.
+async fn mailbox_account_id(
+    connection: &mut SqliteConnection,
+    params_account: u32,
+) -> Result<Option<u32>> {
+    let seed: Option<(String,)> =
+        sqlx::query_as("SELECT seed FROM dkg_params WHERE account = ?")
+            .bind(params_account)
+            .fetch_optional(&mut *connection)
+            .await?;
+    let Some((seed,)) = seed else {
+        return Ok(None);
+    };
+    if seed.is_empty() {
+        return Ok(None);
+    }
+    let r: Option<(u32,)> = sqlx::query_as("SELECT id_account FROM accounts WHERE seed = ?1")
+        .bind(&seed)
+        .fetch_optional(&mut *connection)
+        .await?;
+    Ok(r.map(|(a,)| a))
+}

--- a/rust/src/frost/dkg/step.rs
+++ b/rust/src/frost/dkg/step.rs
@@ -1,0 +1,148 @@
+//! One DKG pass, without waiting.
+//!
+//! The shared entry point behind both front ends: `api::frost` exposes it to
+//! Flutter and the GraphQL server calls it directly. A pass executes every
+//! effect the planner names until it hits a wait or the protocol completes —
+//! the same multi-round advance per invocation the sequential orchestrator
+//! performed, one precondition-checked effect at a time. The caller syncs
+//! first if fresh memo data matters; like [`crate::migrate::step::step_once`],
+//! the step itself never synchronizes.
+
+use anyhow::{bail, Context, Result};
+use sqlx::SqliteConnection;
+
+use crate::{api::coin::Network, Client};
+
+use super::{
+    exec,
+    plan::next_task,
+    state::observe,
+    task::{DkgTask, TaskKind},
+};
+
+/// What one pass did. `executed` ends with the wait/terminal task the pass
+/// stopped on — planned but not executed — so a front end can show where
+/// things stand without re-observing.
+pub struct DkgStepOutcome {
+    pub executed: Vec<DkgTask>,
+    /// The shared address, once the frost account exists.
+    pub shared_address: Option<String>,
+    /// A publish could not be funded yet: the note we spent for the previous
+    /// round is locked and its change is not mined, so there is nothing to
+    /// spend. Transient — the staged `pending_publish` is kept and the caller
+    /// retries on the next block. Surfaced as a warning, never an error.
+    pub waiting_for_funds: bool,
+}
+
+/// Run one pass for `account`.
+///
+/// The account is explicit rather than read from `c.account`: a caller holding
+/// a process-wide coin — the GraphQL server does — must step the wallet it was
+/// asked about, not whichever one the coin happens to name.
+pub async fn dkg_step(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    client: &mut Client,
+    height: u32,
+    account: u32,
+) -> Result<DkgStepOutcome> {
+    let mut executed = Vec::new();
+    let mut shared_address = None;
+
+    // Effects per pass are bounded (three publishes plus three finalize
+    // stages); the cap turns a would-be hot loop into an error.
+    for _ in 0..16 {
+        let state = observe(network, connection, account).await?;
+        let task = next_task(&state);
+
+        if !matches!(task.kind(), TaskKind::Effect) {
+            executed.push(task);
+            return Ok(DkgStepOutcome {
+                executed,
+                shared_address,
+                waiting_for_funds: false,
+            });
+        }
+
+        // Re-validate before touching anything. The snapshot the task was
+        // planned from is an observe old, and a concurrent step — the app and
+        // the GraphQL server can drive the same wallet — may have moved the
+        // protocol underneath it. A stale task is re-planned, never executed.
+        let fresh = observe(network, connection, account).await?;
+        if !task.is_satisfied_by(&fresh) {
+            tracing::info!("DKG task {task:?} no longer applies; replanning");
+            continue;
+        }
+
+        match task {
+            DkgTask::EnsureAccounts => {
+                exec::ensure_accounts(network, connection, account, &fresh.params).await?;
+            }
+            DkgTask::PublishRound { round } => {
+                match exec::publish_round(
+                    network, connection, client, account, height, round, &fresh,
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    // No spendable note yet: the previous round's change is not
+                    // mined. `stage()` already committed the secret and the
+                    // pending bytes, so bail out of the pass as a wait — the
+                    // caller retries on the next block and the resend goes
+                    // through once the change confirms.
+                    Err(e) if crate::pay::plan::is_no_feasible_selection(&e) => {
+                        tracing::warn!(
+                            "DKG round {round} publish deferred: no spendable note yet; \
+                             will retry on the next block"
+                        );
+                        return Ok(DkgStepOutcome {
+                            executed,
+                            shared_address,
+                            waiting_for_funds: true,
+                        });
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            DkgTask::FinalizeKey => {
+                exec::finalize_key(connection, account, &fresh).await?;
+            }
+            DkgTask::CreateFrostAccount => {
+                let broadcast = fresh.broadcast.context("broadcast account missing")?;
+                shared_address = Some(
+                    exec::create_frost_account(network, connection, account, broadcast, height)
+                        .await?,
+                );
+            }
+            DkgTask::CompleteFinalize => {
+                let frost_account = fresh.frost_account.context("frost account missing")?;
+                exec::complete_finalize(
+                    connection,
+                    account,
+                    frost_account,
+                    fresh.mailbox,
+                    fresh.broadcast,
+                )
+                .await?;
+                // The rekey moved the protocol rows and the cleanup deleted
+                // the props, so this is the pass's last act: report the shared
+                // address from the frost account's stored group key.
+                if shared_address.is_none() {
+                    shared_address =
+                        Some(exec::shared_address(network, connection, frost_account).await?);
+                }
+                executed.push(task);
+                return Ok(DkgStepOutcome {
+                    executed,
+                    shared_address,
+                    waiting_for_funds: false,
+                });
+            }
+            DkgTask::WaitAddresses | DkgTask::WaitRound { .. } | DkgTask::Done => {
+                unreachable!("non-effect task handled above")
+            }
+        }
+        executed.push(task);
+    }
+    bail!("DKG pass executed too many effects without reaching a wait; aborting")
+}

--- a/rust/src/frost/dkg/task.rs
+++ b/rust/src/frost/dkg/task.rs
@@ -1,0 +1,83 @@
+//! The unit of DKG work.
+//!
+//! A task is plain data: it names an action without performing it, so the
+//! same value can be planned, displayed, re-validated against fresh state,
+//! and only then executed. This is the discipline the note migration
+//! ([`crate::migrate::task`]) established for a single wallet, extended to a
+//! multi-party protocol where progress depends on other participants'
+//! packages arriving.
+
+use super::state::DkgState;
+
+/// What kind of work a task represents. A driver uses this to decide how to
+/// run it: a wait ends the pass, an effect carries a precondition that is
+/// re-checked against fresh state before it runs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TaskKind {
+    /// Nothing to do but wait — the pass stops here.
+    Time,
+    /// Touches the wallet database or the chain.
+    Effect,
+    /// Nothing left to do.
+    Terminal,
+}
+
+/// One step of the DKG.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DkgTask {
+    /// Not all n participant addresses are known yet.
+    WaitAddresses,
+    /// Create the private mailbox and shared broadcast accounts if missing.
+    EnsureAccounts,
+    /// Publish our outgoing package for `round` (0..3): produce it if our
+    /// secret is not stored yet, then send whatever bytes are staged.
+    PublishRound { round: u8 },
+    /// Peer packages for `round` are still incoming. The all-n discipline:
+    /// every participant's package must arrive before the round advances, so
+    /// each wallet materializes the same complete key set.
+    WaitRound { round: u8 },
+    /// dkg::part3 — derive our key package and the group public key package.
+    FinalizeKey,
+    /// Create the shared frost account holding the group spending key.
+    CreateFrostAccount,
+    /// Rekey the dkg_* rows onto the frost account and tear down the helper
+    /// accounts. The last effect of the protocol.
+    CompleteFinalize,
+    /// No further progress is possible.
+    Done,
+}
+
+impl DkgTask {
+    pub fn kind(&self) -> TaskKind {
+        match self {
+            DkgTask::WaitAddresses | DkgTask::WaitRound { .. } => TaskKind::Time,
+            DkgTask::EnsureAccounts
+            | DkgTask::PublishRound { .. }
+            | DkgTask::FinalizeKey
+            | DkgTask::CreateFrostAccount
+            | DkgTask::CompleteFinalize => TaskKind::Effect,
+            DkgTask::Done => TaskKind::Terminal,
+        }
+    }
+
+    /// Whether this task is still valid against freshly observed state.
+    ///
+    /// A task is planned from one snapshot and executed against another: a
+    /// sync lands, a peer's package arrives, another driver — the app and the
+    /// GraphQL server can drive the same wallet — advanced the protocol.
+    /// Re-checking here turns a stale plan into a re-plan rather than a
+    /// repeated publish.
+    pub fn is_satisfied_by(&self, s: &DkgState) -> bool {
+        match self {
+            DkgTask::WaitAddresses | DkgTask::WaitRound { .. } | DkgTask::Done => true,
+            DkgTask::EnsureAccounts => s.mailbox.is_none() || s.broadcast.is_none(),
+            DkgTask::PublishRound { round } => {
+                let rs = &s.rounds[*round as usize];
+                !rs.secret_present || rs.pending == Some(*round)
+            }
+            DkgTask::FinalizeKey => !s.key_pkg_present,
+            DkgTask::CreateFrostAccount => s.frost_account.is_none(),
+            DkgTask::CompleteFinalize => true,
+        }
+    }
+}

--- a/rust/src/frost/mod.rs
+++ b/rust/src/frost/mod.rs
@@ -3,6 +3,6 @@ pub mod protocol;
 pub mod sign;
 
 pub use protocol::{
-    run_round, to_arb_memo, Broadcast, Dispatch, FrostBytes, FrostMessage, FrostSigMessage,
-    Indexed, NoSend, PK1Map, PK2Map, PerPeer, Round, RouteCtx, ToCoordinator, P,
+    to_arb_memo, Broadcast, Dispatch, FrostBytes, FrostMessage, FrostSigMessage, Indexed, NoSend,
+    PK1Map, PK2Map, PerPeer, Round, RouteCtx, ToCoordinator, P,
 };

--- a/rust/src/frost/protocol.rs
+++ b/rust/src/frost/protocol.rs
@@ -15,7 +15,7 @@ use reddsa::frost::redpallas::{
     keys::dkg::{round1, round2},
     Identifier, PallasBlake2b512, Randomizer,
 };
-use sqlx::{sqlite::SqliteRow, Connection, Row, SqliteConnection};
+use sqlx::{sqlite::SqliteRow, Row, SqliteConnection};
 use tracing::info;
 use zcash_keys::address::UnifiedAddress;
 use zcash_protocol::memo::Memo;
@@ -311,9 +311,6 @@ pub trait Round {
     /// 4-byte memo prefix that identifies messages for this round.
     const PREFIX: [u8; 4];
 
-    /// Minimum number of peer packages required to advance.
-    fn threshold(n: u8, t: u8) -> usize;
-
     /// Pure: given the previous round's output, compute our secret and
     /// the outgoing package(s).
     fn produce(input: &Self::Input) -> Result<(Self::Secret, Self::Outgoing)>;
@@ -355,11 +352,14 @@ pub trait Round {
     ) -> Result<Vec<(u8, Self::Public)>>;
 }
 
-// ── Generic round engine ─────────────────────────────────────────────────────
+// ── Memo ingest ──────────────────────────────────────────────────────────────
 
 /// Decode memos from `mailbox_account`, filter by `R::PREFIX`, deserialize
 /// each as a `FrostMessage`, and store the public package via `R::store_public`.
-async fn decode_dkg_memos<R: Round>(
+///
+/// Idempotent: `dkg_peers`' primary key `(account, round, from_id)` dedups,
+/// so re-ingesting the same memos is a no-op.
+pub async fn decode_dkg_memos<R: Round>(
     conn: &mut SqliteConnection,
     account: u32,
     mailbox_account: u32,
@@ -388,77 +388,6 @@ async fn decode_dkg_memos<R: Round>(
         }
     }
     Ok(())
-}
-
-/// Drive one round of a FROST protocol.
-///
-/// 1. Decodes incoming memos from `mailbox_account` and stores peer packages.
-/// 2. If our own secret is not yet produced, calls `R::produce`, stores the
-///    secret, and publishes outgoing packages to the network (in a DB tx).
-/// 3. Checks whether enough peer packages have arrived (`R::threshold`).
-/// 4. If ready, assembles and returns `R::Output` via `R::collect`.
-///    Returns `None` when still waiting for peer messages.
-#[allow(clippy::too_many_arguments)]
-pub async fn run_round<R: Round>(
-    conn: &mut SqliteConnection,
-    account: u32,
-    n: u8,
-    t: u8,
-    self_id: u8,
-    funding_account: u32,
-    mailbox_account: u32,
-    input: R::Input,
-    route_ctx: &RouteCtx,
-    network: &Network,
-    client: &mut Client,
-    height: u32,
-) -> Result<Option<R::Output>> {
-    // 1. Decode incoming peer packages from memos
-    decode_dkg_memos::<R>(conn, account, mailbox_account).await?;
-
-    // 2. Produce our own secret + outgoing packages if not yet done
-    if R::load_secret(conn, account).await?.is_none() {
-        let (secret, outgoing) =
-            R::produce(&input).context(format!("Round produce failed for account {}", account))?;
-        let recipients_raw = outgoing.into_recipients(route_ctx)?;
-
-        let mut tx = conn.begin().await?;
-        R::store_secret(&mut *tx, account, &secret).await?;
-        if !recipients_raw.is_empty() {
-            let recipients: Vec<(String, Vec<u8>)> = recipients_raw
-                .into_iter()
-                .map(|(addr, data)| {
-                    let msg = FrostMessage {
-                        from_id: self_id,
-                        data,
-                    };
-                    let bytes = msg.encode_with_prefix(&R::PREFIX)?;
-                    Ok((addr, bytes))
-                })
-                .collect::<Result<_>>()?;
-            let refs: Vec<(&str, Vec<u8>)> = recipients
-                .iter()
-                .map(|(a, d)| (a.as_str(), d.clone()))
-                .collect();
-            publish(network, &mut *tx, funding_account, client, height, &refs).await?;
-        }
-        tx.commit().await?;
-    }
-
-    // 3. Check if enough peer packages have arrived
-    let peers = R::load_publics(conn, account).await?;
-    // Filter out our own package, then check threshold (accounting that we have our own package)
-    let peer_count = peers.iter().filter(|(id, _)| *id != self_id).count();
-    if peer_count + 1 < R::threshold(n, t) {
-        // +1 for our own package
-        return Ok(None);
-    }
-
-    // 4. Collect and advance to the next round
-    let secret = R::load_secret(conn, account).await?.unwrap();
-    R::collect(input, secret, peers)
-        .context(format!("Round collect failed for account {}", account))
-        .map(Some)
 }
 
 /// Wire message used during DKG rounds.
@@ -660,6 +589,61 @@ pub async fn get_mailbox_account(
     Ok((account, mailbox_address))
 }
 
+/// Seed of the shared broadcast account: a deterministic function of the
+/// participant addresses, so every participant derives the same account.
+fn broadcast_seed(addresses: &[String]) -> String {
+    let mut state = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"Zcash__FROST_DKG")
+        .to_state();
+    for a in addresses.iter() {
+        state.update(a.as_bytes());
+    }
+    let hash = state.finalize();
+    let m = Mnemonic::from_entropy(hash.as_ref()).expect("Failed to create mnemonic from hash");
+    m.to_string()
+}
+
+/// Look up the shared broadcast account without creating it. Returns the
+/// account id and its encoded unified address, or `None` when the account
+/// does not exist or any participant address is still missing.
+pub async fn lookup_broadcast_account(
+    network: &Network,
+    connection: &mut SqliteConnection,
+    account: u32,
+) -> Result<Option<(u32, String)>> {
+    let addresses = sqlx::query_as::<_, (String,)>(
+        "SELECT address FROM dkg_addresses WHERE account = ?1 ORDER BY from_id",
+    )
+    .bind(account)
+    .fetch_all(&mut *connection)
+    .await?;
+    let addresses = addresses.into_iter().map(|row| row.0).collect::<Vec<_>>();
+    if addresses.iter().any(|a| a.is_empty()) {
+        return Ok(None);
+    }
+    let seed = broadcast_seed(&addresses);
+
+    let r = sqlx::query_as::<_, (u32, Vec<u8>)>(
+        "SELECT a.id_account, o.xvk FROM accounts a
+        JOIN orchard_accounts o ON a.id_account = o.account
+        WHERE seed = ?1",
+    )
+    .bind(&seed)
+    .fetch_optional(&mut *connection)
+    .await?;
+    match r {
+        None => Ok(None),
+        Some((account, xvk)) => {
+            let fvk = FullViewingKey::from_bytes(&xvk.try_into().unwrap())
+                .expect("Failed to create shared FVK");
+            let address = fvk.address_at(0u64, Scope::External);
+            let ua = UnifiedAddress::from_receivers(Some(address), None, None).unwrap();
+            Ok(Some((account, ua.encode(network))))
+        }
+    }
+}
+
 /// Get (and create if needed) the shared broadcast address for
 /// communication between all participants in the group.
 /// It is derived from the hash of the participant private mailbox addresses.
@@ -677,17 +661,7 @@ pub async fn get_coordinator_broadcast_account(
     .fetch_all(&mut *connection)
     .await?;
     let addresses = addresses.into_iter().map(|row| row.0).collect::<Vec<_>>();
-
-    let mut state = blake2b_simd::Params::new()
-        .hash_length(32)
-        .personal(b"Zcash__FROST_DKG")
-        .to_state();
-    for a in addresses.iter() {
-        state.update(a.as_bytes());
-    }
-    let hash = state.finalize();
-    let m = Mnemonic::from_entropy(hash.as_ref()).expect("Failed to create mnemonic from hash");
-    let seed = m.to_string();
+    let seed = broadcast_seed(&addresses);
 
     let (account, broadcast_address) = loop {
         // Check if the account already exists

--- a/rust/src/frost/sign.rs
+++ b/rust/src/frost/sign.rs
@@ -39,7 +39,6 @@ use crate::{
         coin::Network,
         frost::{FrostSignParams, SigningStatus},
         pay::PcztPackage,
-        sync::SYNCING,
     },
     frost::dkg::{
         delete_frost_state, get_coordinator_broadcast_account, get_dkg_params, get_mailbox_account,
@@ -236,12 +235,6 @@ pub async fn do_sign_impl(
     };
     info!("sign: found PCZT, signing is in progress");
 
-    let guard = SYNCING.try_lock();
-    if guard.is_err() {
-        info!("sign: sync already in progress, skipping");
-        return Ok(());
-    }
-
     let birth_height = height.saturating_sub(10000) + 1;
     let params = get_sign_params(&mut *connection).await?;
     info!(
@@ -382,7 +375,7 @@ pub async fn do_sign_impl(
                 recipients.len()
             );
             status.send(SigningStatus::SendingCommitment).await;
-            let txid = publish(
+            let txid = match publish(
                 network,
                 &mut tx,
                 params.funding_account,
@@ -390,7 +383,18 @@ pub async fn do_sign_impl(
                 height,
                 &recipients,
             )
-            .await?;
+            .await
+            {
+                core::result::Result::Ok(txid) => txid,
+                // Funding note locked and its change not mined yet: drop the tx
+                // (nothing persisted) and wait for the next block.
+                Err(e) if crate::pay::plan::is_no_feasible_selection(&e) => {
+                    info!("sign: commitment publish deferred; retry next block");
+                    status.send(SigningStatus::WaitingForFunds).await;
+                    return Ok(());
+                }
+                Err(e) => return Err(e),
+            };
             info!("Published commitment transaction: {}", txid);
         }
         tx.commit().await?;
@@ -521,7 +525,7 @@ pub async fn do_sign_impl(
         // we send all the sigpackages in one zcash transaction
         // with one output/memo per input/signature needed
         status.send(SigningStatus::SendingSigningPackage).await;
-        let txid = publish(
+        let txid = match publish(
             network,
             &mut tx,
             params.funding_account,
@@ -529,7 +533,16 @@ pub async fn do_sign_impl(
             height,
             &recipients,
         )
-        .await?;
+        .await
+        {
+            core::result::Result::Ok(txid) => txid,
+            Err(e) if crate::pay::plan::is_no_feasible_selection(&e) => {
+                info!("sign: sigpackage publish deferred; retry next block");
+                status.send(SigningStatus::WaitingForFunds).await;
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
         info!("Published sigpackages transaction: {}", txid);
         // we got all the sigshares, commit them
         tx.commit().await?;
@@ -590,7 +603,7 @@ pub async fn do_sign_impl(
 
         if dkg_params.id as u8 != params.coordinator {
             status.send(SigningStatus::SendingSignatureShare).await;
-            let txid = publish(
+            let txid = match publish(
                 network,
                 &mut tx,
                 params.funding_account,
@@ -598,7 +611,16 @@ pub async fn do_sign_impl(
                 height,
                 &recipients,
             )
-            .await?;
+            .await
+            {
+                core::result::Result::Ok(txid) => txid,
+                Err(e) if crate::pay::plan::is_no_feasible_selection(&e) => {
+                    info!("sign: sigshare publish deferred; retry next block");
+                    status.send(SigningStatus::WaitingForFunds).await;
+                    return Ok(());
+                }
+                Err(e) => return Err(e),
+            };
 
             status.send(SigningStatus::SigningCompleted).await;
             info!("Published sigshares transaction: {}", txid);

--- a/rust/src/graphql/frost.rs
+++ b/rust/src/graphql/frost.rs
@@ -1,12 +1,10 @@
 use bincode::config;
 use juniper::{FieldError, FieldResult};
-use sqlx::{query, sqlite::SqliteRow, Row};
 
 use crate::{
     api::{coin::Coin, frost::get_funding_account},
     frost::{dkg::in_dkg, sign::in_sign},
     graphql::Context,
-    sync::{synchronize_impl, DEFAULT_ACTIONS_PER_SYNC},
 };
 
 pub async fn dkg_start(
@@ -67,32 +65,16 @@ pub async fn new_block(coin: Coin) -> anyhow::Result<()> {
 
     let account = get_funding_account(&mut connection).await?;
     tracing::info!("funding: {account}");
-    let mut frost_accounts =
-        query("SELECT id_account FROM accounts WHERE name LIKE 'frost-%' AND internal = 1")
-            .map(|r: SqliteRow| r.get::<u32, _>(0))
-            .fetch_all(&mut *connection)
-            .await?;
-    frost_accounts.push(account);
-    let height = synchronize_impl(
-        (),
-        frost_accounts,
-        height,
-        DEFAULT_ACTIONS_PER_SYNC,
-        1,
-        100,
-        false,
-        &coin,
-    )
-    .await?;
+    let height =
+        crate::api::frost::sync_frost_accounts(&coin, &mut connection, account, height).await?;
 
     if in_dkg {
-        crate::frost::dkg::do_dkg_impl(
+        crate::frost::dkg::step::dkg_step(
             &coin.network(),
             &mut connection,
-            account,
             &mut client,
             height,
-            (),
+            account,
         )
         .await?;
     }
@@ -110,13 +92,14 @@ pub async fn do_dkg(context: &Context) -> FieldResult<bool> {
     let mut client = coin.client().await?;
     let height = client.latest_height().await?;
     let account = get_funding_account(&mut connection).await?;
-    crate::frost::dkg::do_dkg_impl(
+    let height =
+        crate::api::frost::sync_frost_accounts(coin, &mut connection, account, height).await?;
+    crate::frost::dkg::step::dkg_step(
         &coin.network(),
         &mut connection,
-        account,
         &mut client,
         height,
-        (),
+        account,
     )
     .await?;
     Ok(true)

--- a/rust/src/pay/error.rs
+++ b/rust/src/pay/error.rs
@@ -6,6 +6,12 @@ pub enum Error {
     InvalidPoolMask,
     #[error("Not enough funds, {0} more ZEC required")]
     NotEnoughFunds(String),
+    /// No spendable notes could be selected. In the FROST rounds this is a
+    /// transient "the change we just spent has not been mined yet" condition,
+    /// so it is a distinct variant the callers can recognize and treat as a
+    /// wait rather than a hard failure.
+    #[error("No feasible note selection found")]
+    NoFeasibleSelection,
     #[error("No Signing Key")]
     NoSigningKey,
     #[error(transparent)]

--- a/rust/src/pay/plan.rs
+++ b/rust/src/pay/plan.rs
@@ -232,6 +232,20 @@ fn decompose_address(
     anyhow::bail!("Unrecognized address pool");
 }
 
+/// Whether `e` (anywhere in its cause chain) is the transient
+/// [`Error::NoFeasibleSelection`] raised by [`plan_transaction`]. The FROST
+/// rounds use this to treat "the change we just spent is not mined yet" as a
+/// wait instead of a hard error; the chain is walked so wrapping the error in
+/// `.context(..)` does not hide it.
+pub fn is_no_feasible_selection(e: &anyhow::Error) -> bool {
+    e.chain().any(|c| {
+        matches!(
+            c.downcast_ref::<crate::pay::error::Error>(),
+            Some(crate::pay::error::Error::NoFeasibleSelection)
+        )
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn plan_transaction(
     network: &Network,
@@ -493,7 +507,7 @@ pub async fn plan_transaction(
         recipient_pays_fee,
         recipients.first().map(|r| r.amount).unwrap_or(0),
     )
-    .ok_or_else(|| anyhow!("No feasible note selection found"))?;
+    .ok_or_else(|| anyhow::Error::new(crate::pay::error::Error::NoFeasibleSelection))?;
 
     info!(
         "plan: select_notes succeeded — fee={}, change_pool={}, selected_inputs={}",

--- a/tests/tests/test_dkg_2_of_3.py
+++ b/tests/tests/test_dkg_2_of_3.py
@@ -1,0 +1,321 @@
+"""Test 2-of-3 FROST DKG using GraphQL API.
+
+The DKG is run by ALL n participants regardless of the threshold: rounds
+advance only when every participant's package has arrived, so each wallet
+materializes the same complete key set and any t-subset is valid for signing
+later. This test proves the DKG completes for n=3, t=2.
+"""
+
+import asyncio
+import os
+
+import pytest
+from gql import GraphQLRequest, gql
+
+from conftest import gql_client_factory
+from dkg import DkgParticipant, poll_with_block_mining
+from utils import get_current_height, mine_blocks, wait_for_blocks
+
+
+@pytest.mark.asyncio
+async def test_dkg_2_of_3(graphql_url, rpc_url, seed, zkool_binary, gql_client_factory):
+    """Test 2-of-3 FROST DKG: all 3 participants run the DKG, t=2 for signing."""
+    if not seed:
+        pytest.skip("SEED not set")
+
+    if not os.path.exists(zkool_binary):
+        pytest.skip(f"zkool_graphql binary not found at {zkool_binary}")
+
+    N = 3
+    T = 2
+    DEFAULT_PORT = 8000
+    PORT_BASE = 8101
+    LWD_URL = "http://localhost:8137"
+
+    participants = []
+    default_participant = None
+
+    async def cleanup():
+        for p in participants:
+            await p.stop()
+        if default_participant:
+            await default_participant.stop()
+        for i in range(1, N + 1):
+            log_path = f"/tmp/graphql_{PORT_BASE + i - 1}.log"
+            if os.path.exists(log_path):
+                os.remove(log_path)
+        default_log = "/tmp/graphql_default_2of3.log"
+        if os.path.exists(default_log):
+            os.remove(default_log)
+
+    try:
+        from utils import kill_existing_zkool_processes
+
+        await kill_existing_zkool_processes()
+
+        print("=== Setting up 2-of-3 FROST DKG Test ===")
+        print(f"Starting default instance on port {DEFAULT_PORT}")
+        default_db = "/tmp/regtest_dkg_default_2of3.db"
+        default_participant = DkgParticipant(DEFAULT_PORT, default_db, LWD_URL)
+        default_participant.start(zkool_binary)
+        await asyncio.sleep(2)
+
+        print("\n=== Step 1: Start participant instances ===")
+        for i in range(1, N + 1):
+            port = PORT_BASE + i - 1
+            db_path = f"/tmp/regtest_dkg_2of3_{i}.db"
+            participant = DkgParticipant(port, db_path, LWD_URL)
+            participant.start(zkool_binary)
+            participants.append(participant)
+            print(f"Started participant {i} on port {port}")
+            await asyncio.sleep(2)
+
+        print("\n=== Step 2: Create funded wallet on default instance ===")
+        async with gql_client_factory(graphql_url) as client:
+            create_account_mutation = gql(
+                """
+                mutation ($main: String!) {
+                    createAccount(newAccount: {
+                        name: "Main"
+                        key: $main
+                        aindex: 0
+                        useInternal: false
+                        birth: 1
+                    })
+                }
+                """
+            )
+            result = await client.execute_async(
+                GraphQLRequest(create_account_mutation, variable_values={"main": seed})
+            )
+            main_wallet = int(result["createAccount"])
+            print(f"Funding wallet: {main_wallet}")
+
+            sync_mutation = gql(
+                """
+                mutation ($account: Int!) {
+                    synchronizeAccount(idAccount: $account)
+                }
+                """
+            )
+            await client.execute_async(
+                GraphQLRequest(sync_mutation, variable_values={"account": main_wallet})
+            )
+
+            balance_query = gql(
+                """
+                query ($account: Int!) {
+                    balanceByAccount(idAccount: $account) {
+                        ironwood
+                    }
+                }
+                """
+            )
+            result = await client.execute_async(
+                GraphQLRequest(balance_query, variable_values={"account": main_wallet})
+            )
+            funding_balance = result["balanceByAccount"]["ironwood"]
+            print(f"Funding wallet balance: {funding_balance}")
+
+        print("\n=== Step 3: Initialize DKG for each participant (n=3, t=2) ===")
+        for i, participant in enumerate(participants, 1):
+            create_account_mutation = gql(
+                """
+                mutation {
+                    createAccount(newAccount: {
+                        name: "DKG-Fund"
+                        key: ""
+                        aindex: 0
+                        useInternal: false
+                        birth: 1
+                    })
+                }
+                """
+            )
+            result = await participant.execute(GraphQLRequest(create_account_mutation))
+            participant.funding_account = int(result["createAccount"])
+
+            address_query = gql(
+                """
+                query ($account: Int!) {
+                    addressByAccount(idAccount: $account) {
+                        ironwood
+                    }
+                }
+                """
+            )
+            result = await participant.execute(
+                GraphQLRequest(
+                    address_query, variable_values={"account": participant.funding_account}
+                )
+            )
+            participant.funding_address = result["addressByAccount"]["ironwood"]
+
+            print(f"Participant {i} funding account: {participant.funding_account}")
+            print(f"Participant {i} funding address: {participant.funding_address}")
+
+            dkg_start_mutation = gql(
+                """
+                mutation ($name: String!, $t: Int!, $n: Int!, $funding: Int!, $id: Int!) {
+                    dkgStart(
+                        name: $name
+                        threshold: $t
+                        participants: $n
+                        messageAccount: $funding
+                        idParticipant: $id
+                    )
+                }
+                """
+            )
+            result = await participant.execute(
+                GraphQLRequest(
+                    dkg_start_mutation,
+                    variable_values={
+                        "name": f"Dkg-Test-2of3-{i}",
+                        "t": T,
+                        "n": N,
+                        "funding": participant.funding_account,
+                        "id": i,
+                    },
+                )
+            )
+            participant.dkg_address = result["dkgStart"]
+            print(f"Participant {i} DKG address: {participant.dkg_address}")
+
+        print("\n=== Step 4: Fund each participant's funding address ===")
+        async with gql_client_factory(graphql_url) as client:
+            recipients = [{"address": p.funding_address, "amount": "0.01"} for p in participants]
+
+            pay_mutation = gql(
+                """
+                mutation ($account: Int!, $recipients: [Recipient!]!) {
+                    pay(idAccount: $account, payment: {recipients: $recipients})
+                }
+                """
+            )
+            result = await client.execute_async(
+                GraphQLRequest(
+                    pay_mutation,
+                    variable_values={"account": main_wallet, "recipients": recipients},
+                )
+            )
+            txid = result["pay"]
+            print(f"Funding transaction: {txid}")
+
+        print("\n=== Step 5: Mine blocks for confirmation ===")
+        client = await participants[0].get_client()
+        height = await get_current_height(client)
+        await mine_blocks(rpc_url, 5)
+        await wait_for_blocks(client, height, 5)
+        print("Blocks mined")
+
+        print("\n=== Step 6: Synchronize funding accounts ===")
+        sync_mutation = gql(
+            """
+            mutation ($account: Int!) {
+                synchronizeAccount(idAccount: $account)
+            }
+            """
+        )
+        for i, participant in enumerate(participants, 1):
+            await participant.execute(
+                GraphQLRequest(
+                    sync_mutation, variable_values={"account": participant.funding_account}
+                )
+            )
+            print(f"Synchronized participant {i} funding account")
+
+        print("\n=== Step 7: Verify funding accounts received funds ===")
+        balance_query = gql(
+            """
+            query ($account: Int!) {
+                balanceByAccount(idAccount: $account) {
+                    ironwood
+                }
+            }
+            """
+        )
+        for i, participant in enumerate(participants, 1):
+            result = await participant.execute(
+                GraphQLRequest(
+                    balance_query, variable_values={"account": participant.funding_account}
+                )
+            )
+            balance = result["balanceByAccount"]["ironwood"]
+            print(f"Participant {i} funding account balance: {balance}")
+            assert balance and balance != "0", f"Participant {i} has insufficient balance"
+
+        print("\n=== Step 8: Exchange DKG addresses between participants ===")
+        set_address_mutation = gql(
+            """
+            mutation ($id: Int!, $address: String!) {
+                dkgSetAddress(idParticipant: $id, address: $address)
+            }
+            """
+        )
+        for i, sender in enumerate(participants, 1):
+            for j, receiver in enumerate(participants, 1):
+                if i == j:
+                    continue
+
+                target_address = participants[j - 1].dkg_address
+                await sender.execute(
+                    GraphQLRequest(
+                        set_address_mutation, variable_values={"id": j, "address": target_address}
+                    )
+                )
+                print(f"Participant {i} set address for participant {j}")
+
+        print("\n=== Step 9: Execute DKG on all participants ===")
+        do_dkg_mutation = gql(
+            """
+            mutation {
+                doDkg
+            }
+            """
+        )
+        for i, participant in enumerate(participants, 1):
+            await participant.execute(GraphQLRequest(do_dkg_mutation))
+            print(f"Initiated DKG on participant {i}")
+
+        print("\n=== Step 10: Wait for DKG completion ===")
+
+        async def all_dkg_completed():
+            return all(p.get_frost_account_id() is not None for p in participants)
+
+        success = await poll_with_block_mining(all_dkg_completed, rpc_url, timeout=300)
+        if not success:
+            pytest.fail("DKG timed out")
+        print("All participants completed DKG successfully")
+
+        print("\n=== Step 11: Verify shared address is same for all participants ===")
+        shared_address = None
+        address_query = gql(
+            """
+            query ($account: Int!) {
+                addressByAccount(idAccount: $account) {
+                    ironwood
+                }
+            }
+            """
+        )
+        for i, participant in enumerate(participants, 1):
+            frost_account = participant.get_frost_account_id()
+            assert frost_account is not None, f"Participant {i} has no FROST account"
+            result = await participant.execute(
+                GraphQLRequest(address_query, variable_values={"account": frost_account})
+            )
+            addr = result["addressByAccount"]["ironwood"]
+            print(f"Participant {i} shared address: {addr}")
+            if shared_address is None:
+                shared_address = addr
+            else:
+                assert addr == shared_address, f"Participant {i} has a different shared address"
+
+        print(f"\n=== ✅ 2-of-3 DKG Test Passed! ===")
+        print(f"Shared FROST address: {shared_address}")
+        print("All 3 participants completed the DKG despite t=2:")
+        print("  - every wallet materialized the same complete key set")
+
+    finally:
+        await cleanup()


### PR DESCRIPTION
## Summary

Refactors the DKG rounds into a `plan`/`step`/`exec`/`state` pipeline (mirroring the note migration) and makes both `do_dkg` and `do_sign` **depend on the wallet's autosync** rather than syncing themselves. This fixes the Flutter UI DKG test, which failed because `do_dkg`'s self-sync could be silently skipped under `SYNCING` contention.

## What changed

- **No self-sync in `do_dkg`/`do_sign`.** They no longer call `sync_frost_accounts`/`synchronize_impl`; they step against what is already synced. The Flutter pages force a sync per block and then step; the headless server keeps syncing in `graphql::frost::new_block`.
- **Transient "nothing to spend" is a wait, not an error.** A publish whose funding note is locked with its change not yet mined is surfaced as a new `WaitingForFunds` status (info/warning) and retried on the next block. `plan_transaction` returns a typed `NoFeasibleSelection` error so the FROST path can recognize it while normal `pay` still reports insufficient funds.
- **Double-spend safety** rests on the broadcast-time note lock (`notes.locked`), which sync releases only once the spend is mined — so a concurrent sync can never re-select an in-flight note.
- **Block-driven retry.** DKGPage3/FrostPage2 replace the 30s timer with a block-height subscription (one step per block, deduped so the warning shows at most once per block), serialize passes to avoid overlapping publishes (which would double-spend), and drop the `frostInProgress` autosync guard.

## Testing

All FROST integration tests pass on a local regtest chain:

| Test | Result |
|---|---|
| `test_dkg_2_of_3.py` (headless 2-of-3 DKG) | ✅ |
| `test_dkg.py` (headless 3-of-3 DKG) | ✅ |
| `test_frost.py` (headless signing, receiver paid) | ✅ |
| `test_dkg_ui.py` (Flutter UI DKG) | ✅ |
| `test_frost_ui.py` (Flutter UI signing, receiver paid) | ✅ |

Adds a 2-of-3 headless DKG test.